### PR TITLE
Surround env variables with quotes

### DIFF
--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -299,7 +299,7 @@ public class DockerServiceTests
         _processService.Setup(handler =>
             handler.RunAsync(
                 "docker",
-                $"run --rm -t --env GITHUB_ACCESS_TOKEN=foo --env GITHUB_INSTANCE_URL=https://github.fabrikam.com --env JENKINS_ACCESS_TOKEN=bar -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
+                $"run --rm -t --env \"GITHUB_ACCESS_TOKEN=foo\" --env \"GITHUB_INSTANCE_URL=https://github.fabrikam.com\" --env \"JENKINS_ACCESS_TOKEN=bar\" -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
                 Directory.GetCurrentDirectory(),
                 new[] { new ValueTuple<string, string>("MSYS_NO_PATHCONV", "1") },
                 true

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -121,7 +121,7 @@ public class DockerService : IDockerService
             if (key.StartsWith("GH_", StringComparison.Ordinal))
                 key = key.Replace("GH_", "GITHUB_", StringComparison.Ordinal);
 
-            yield return $"--env {key}={value}";
+            yield return $"--env \"{key}={value}\"";
         }
     }
 


### PR DESCRIPTION
## What's changing?

This updates the `DockerService` to surround `--env` options in quotes so that values containing spaces are valid.

## How's this tested?

- Specs

```console
NO_PROXY="localhost, 127.0.0.1, ::1, .XXX.de, .YYY.de" dotnet run --project ActionsImporter/ActionsImporter.csproj -- dry-run ...
```

Closes #6 
