### PR TITLE
Terminate error messages with newline

### DIFF
--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -54,6 +54,6 @@ try
 }
 catch (Exception e)
 {
-    await Console.Error.WriteAsync(e.Message);
+    await Console.Error.WriteLineAsync(e.Message);
     return 1;
 }


### PR DESCRIPTION
## What's changing?

This ensures that error messages get terminated with a newline character.

## How's this tested?

```bash
$ docker images rm ghcr.io/actions-importer/cli
$ dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- audit jenkins -o output
```

Closes #16
