### PR TITLE
Updating options on GH-Actions-Importer with new ADO options

### DIFF
--- a/src/ActionsImporter.UnitTests/ActionsImporter.UnitTests.csproj
+++ b/src/ActionsImporter.UnitTests/ActionsImporter.UnitTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="JUnitTestLogger" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />

--- a/src/ActionsImporter/Commands/AzureDevOps/Audit.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Audit.cs
@@ -13,6 +13,12 @@ public class Audit : ContainerCommand
     protected override string Name => "azure-devops";
     protected override string Description => "An audit will output a list of data used in an Azure DevOps instance.";
 
+    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    {
+        Description = "The file path corresponding to the Azure DevOps configuration file.",
+        IsRequired = false,
+    };
+
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
         Common.Organization,
         Common.Project,

--- a/src/ActionsImporter/Commands/AzureDevOps/Audit.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Audit.cs
@@ -20,7 +20,7 @@ public class Audit : ContainerCommand
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        ConfigFilePath
+        ConfigFilePath,
         Common.Organization,
         Common.Project,
         Common.InstanceUrl,

--- a/src/ActionsImporter/Commands/AzureDevOps/Audit.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Audit.cs
@@ -20,6 +20,7 @@ public class Audit : ContainerCommand
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        ConfigFilePath
         Common.Organization,
         Common.Project,
         Common.InstanceUrl,

--- a/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,13 +12,8 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
-    {
-        Description = "The file path corresponding to the Azure DevOps pipeline file.",
-        IsRequired = false,
-    };
-
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        SourceFilePath
+        Common.SourceFilePath,
+        Common.PipelineIdNotRequired
     );
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -19,6 +19,7 @@ public class DryRun : ContainerCommand
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        PipelineId,
         Common.SourceFilePath
     );
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -11,5 +11,14 @@ public class DryRun : ContainerCommand
 
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+
+    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    {
+        Description = "The Azure DevOps pipeline id.",
+        IsRequired = false,
+    };
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.SourceFilePath
+    );
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,7 +12,7 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    public static readonly Option<int> PipelineId = new(new[] { "-i", "--pipeline-id" })
     {
         Description = "The Azure DevOps pipeline id.",
         IsRequired = false,

--- a/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,13 +12,13 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
+    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
     {
-        Description = "The file path corresponding to the Azure DevOps configuration file.",
+        Description = "The file path corresponding to the Azure DevOps pipeline file.",
         IsRequired = false,
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        ConfigFilePath
+        SourceFilePath
     );
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/DryRun.cs
@@ -12,14 +12,13 @@ public class DryRun : ContainerCommand
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
 
-    public static readonly Option<int> PipelineId = new(new[] { "-i", "--pipeline-id" })
+    private static readonly Option<FileInfo> ConfigFilePath = new("--config-file-path")
     {
-        Description = "The Azure DevOps pipeline id.",
+        Description = "The file path corresponding to the Azure DevOps configuration file.",
         IsRequired = false,
     };
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
-        PipelineId,
-        Common.SourceFilePath
+        ConfigFilePath
     );
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/Migrate.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/BuildPipeline/Migrate.cs
@@ -11,5 +11,8 @@ public class Migrate : ContainerCommand
 
     protected override string Name => "pipeline";
     protected override string Description => "Target a designer or YAML pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.SourceFilePath,
+        Common.PipelineIdNotRequired
+    );
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/Common.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Common.cs
@@ -33,10 +33,4 @@ public static class Common
         Description = "The Azure DevOps pipeline id.",
         IsRequired = true,
     };
-
-    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
-    {
-        Description = "The file path corresponding to the Azure DevOps pipeline file.",
-        IsRequired = false,
-    };
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/Common.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Common.cs
@@ -28,7 +28,7 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<int> PipelineId = new(new[] { "--pipeline-id", "-i" })
+    public static readonly Option<int> PipelineId = new(new[] {"-i", "--pipeline-id"})
     {
         Description = "The Azure DevOps pipeline id.",
         IsRequired = true,

--- a/src/ActionsImporter/Commands/AzureDevOps/Common.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Common.cs
@@ -28,9 +28,21 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<int> PipelineId = new(new[] { "-i", "--pipeline-id" })
+    public static readonly Option<int> PipelineIdRequired = new(new[] { "--pipeline-id", "-i" })
     {
-        Description = "The Azure DevOps pipeline id.",
+        Description = "The Azure DevOps pipeline ID.",
         IsRequired = true,
+    };
+
+    public static readonly Option<int> PipelineIdNotRequired = new(new[] { "--pipeline-id", "-i" })
+    {
+        Description = "The Azure DevOps pipeline ID.",
+        IsRequired = false,
+    };
+
+    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
+    {
+        Description = "The file path corresponding to the Azure DevOps pipeline file.",
+        IsRequired = false,
     };
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/Common.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Common.cs
@@ -33,4 +33,10 @@ public static class Common
         Description = "The Azure DevOps pipeline id.",
         IsRequired = true,
     };
+
+    public static readonly Option<FileInfo> SourceFilePath = new("--source-file-path")
+    {
+        Description = "The file path corresponding to the Azure DevOps pipeline file.",
+        IsRequired = false,
+    };
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/Common.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Common.cs
@@ -28,7 +28,7 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<int> PipelineId = new(new[] {"-i", "--pipeline-id"})
+    public static readonly Option<int> PipelineId = new(new[] { "-i", "--pipeline-id" })
     {
         Description = "The Azure DevOps pipeline id.",
         IsRequired = true,

--- a/src/ActionsImporter/Commands/AzureDevOps/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/DryRun.cs
@@ -17,7 +17,7 @@ public class DryRun : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-        
+
         command.AddGlobalOption(Common.InstanceUrl);
         command.AddGlobalOption(Common.Organization);
         command.AddGlobalOption(Common.Project);

--- a/src/ActionsImporter/Commands/AzureDevOps/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/DryRun.cs
@@ -17,8 +17,7 @@ public class DryRun : BaseCommand
     protected override Command GenerateCommand(App app)
     {
         var command = base.GenerateCommand(app);
-
-        command.AddGlobalOption(Common.PipelineId);
+        
         command.AddGlobalOption(Common.InstanceUrl);
         command.AddGlobalOption(Common.Organization);
         command.AddGlobalOption(Common.Project);

--- a/src/ActionsImporter/Commands/AzureDevOps/Migrate.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/Migrate.cs
@@ -18,7 +18,6 @@ public class Migrate : BaseCommand
     {
         var command = base.GenerateCommand(app);
 
-        command.AddGlobalOption(Common.PipelineId);
         command.AddGlobalOption(Common.InstanceUrl);
         command.AddGlobalOption(Common.Organization);
         command.AddGlobalOption(Common.Project);

--- a/src/ActionsImporter/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/ReleasePipeline/DryRun.cs
@@ -11,5 +11,7 @@ public class DryRun : ContainerCommand
 
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.PipelineIdRequired
+    );
 }

--- a/src/ActionsImporter/Commands/AzureDevOps/ReleasePipeline/Migrate.cs
+++ b/src/ActionsImporter/Commands/AzureDevOps/ReleasePipeline/Migrate.cs
@@ -11,5 +11,7 @@ public class Migrate : ContainerCommand
 
     protected override string Name => "release";
     protected override string Description => "Target a release pipeline";
-    protected override ImmutableArray<Option> Options => ImmutableArray<Option>.Empty;
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.PipelineIdRequired
+    );
 }


### PR DESCRIPTION
## What's changing?
Make sure you have the latest version of the Valet container: 
`gh actions-importer update`

Build c# project:
`dotnet build src/ActionsImporter/ActionsImporter.csproj `

Make sure you add a sample ADO pipeline to `output/pipeline.yml`
```
trigger:
- main

pool:
  vmImage: ubuntu-latest

steps:
- script: echo Hello, world!
  displayName: 'Run a one-line script'

- script: |
    echo Add other tasks to build, test, and deploy your project.
    echo See https://aka.ms/yaml
  displayName: 'Run a multi-line script'
```

also `output/config.yaml`:
```
pipelines:
  - project_slug: valet-testing/unit/basic-pipeline-sample
    source_file_path: output/pipeline.yml
  - project_slug: valet-testing/unit/directed-acrylic-graph-pipeline
    source_file_path: output/pipeline.yml

```

Regular commands: 
`dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- dry-run azure-devops pipeline --pipeline-id 427 -o "output"` 

`dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- migrate azure-devops pipeline --pipeline-id 427 -o "output" --target-url "https://github.com/begonaguereca/demo"`

`dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- audit azure-devops -o "output"`
________________________________

Commands with config options:

Run a dry-run with `source-file-path`:
`dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- dry-run azure-devops pipeline -o "output" --source-file-path output/pipeline.yml`

Run for migrate with `source-file-path`: 
`dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- migrate azure-devops pipeline -o "output" --source-file-path output/pipeline.yml --target-url "https://github.com/begonaguereca/demo"`

Run for audit with a `config-file-path`: 
`dotnet run --project src/ActionsImporter/ActionsImporter.csproj-- audit azure-devops -o "output" --config-file-path "output/config.yml" `

## How's this tested?

Closes [related issues]
