### PR TITLE
Forward USER_ID and GROUP_ID to actions-importer on Linux

### DIFF
--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -15,13 +15,15 @@ public class DockerServiceTests
 #pragma warning disable CS8618
     private DockerService _dockerService;
     private Mock<IProcessService> _processService;
+    private Mock<IRuntimeService> _runtimeService;
 #pragma warning restore CS8618
 
     [SetUp]
     public void BeforeEachTest()
     {
         _processService = new Mock<IProcessService>();
-        _dockerService = new DockerService(_processService.Object);
+        _runtimeService = new Mock<IRuntimeService>();
+        _dockerService = new DockerService(_processService.Object, _runtimeService.Object);
     }
 
     [TearDown]
@@ -328,6 +330,33 @@ public class DockerServiceTests
             handler.RunAsync(
                 "docker",
                 $"run --rm -t --network=host -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
+                Directory.GetCurrentDirectory(),
+                new[] { new ValueTuple<string, string>("MSYS_NO_PATHCONV", "1") },
+                true
+            )
+        ).Returns(Task.CompletedTask);
+
+        // Act
+        await _dockerService.ExecuteCommandAsync(image, server, version, arguments);
+
+        // Assert
+        _processService.VerifyAll();
+    }
+
+    [Test]
+    public async Task ExecuteCommandAsync_InvokesDocker_OnLinuxOS_ReturnsTrue()
+    {
+        // Arrange
+        var image = "actions-importer/cli";
+        var server = "ghcr.io";
+        var version = "latest";
+        var arguments = new[] { "run", "this", "command" };
+
+        _runtimeService.Setup(handler => handler.IsLinux).Returns(true);
+        _processService.Setup(handler =>
+            handler.RunAsync(
+                "docker",
+                $"run --rm -t -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
                 Directory.GetCurrentDirectory(),
                 new[] { new ValueTuple<string, string>("MSYS_NO_PATHCONV", "1") },
                 true

--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -353,10 +353,19 @@ public class DockerServiceTests
         var arguments = new[] { "run", "this", "command" };
 
         _runtimeService.Setup(handler => handler.IsLinux).Returns(true);
+
+        _processService.Setup(handler =>
+          handler.RunAndCaptureAsync("id", "-u", null, null, true, null)
+        ).Returns(Task.FromResult(("50", "", 0)));
+
+        _processService.Setup(handler =>
+          handler.RunAndCaptureAsync("id", "-g", null, null, true, null)
+        ).Returns(Task.FromResult(("100", "", 0)));
+
         _processService.Setup(handler =>
             handler.RunAsync(
                 "docker",
-                $"run --rm -t -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
+                $"run --rm -t -e USER_ID=50 -e GROUP_ID=100 -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
                 Directory.GetCurrentDirectory(),
                 new[] { new ValueTuple<string, string>("MSYS_NO_PATHCONV", "1") },
                 true

--- a/src/ActionsImporter/Interfaces/IRuntimeService.cs
+++ b/src/ActionsImporter/Interfaces/IRuntimeService.cs
@@ -1,0 +1,6 @@
+﻿namespace ActionsImporter.Interfaces;
+
+public interface IRuntimeService
+{
+    bool IsLinux { get; }
+}

--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -10,7 +10,7 @@ using Version = ActionsImporter.Commands.Version;
 var processService = new ProcessService();
 
 var app = new App(
-    new DockerService(processService),
+    new DockerService(processService, new RuntimeService()),
     processService,
     new ConfigurationService()
 );

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -33,7 +33,7 @@ public class DockerService : IDockerService
         await DockerPullAsync(image, server, version);
     }
 
-    public Task ExecuteCommandAsync(string image, string server, string version, params string[] arguments)
+    public async Task ExecuteCommandAsync(string image, string server, string version, params string[] arguments)
     {
         var actionsImporterArguments = new List<string>
         {
@@ -51,14 +51,16 @@ public class DockerService : IDockerService
         // to ensure the output files are owned by the current user
         if (_runtimeService.IsLinux)
         {
-            actionsImporterArguments.Add("-e USER_ID=$(id -u)");
-            actionsImporterArguments.Add("-e GROUP_ID=$(id -g)");
+            var (userId, _, _) = await _processService.RunAndCaptureAsync("id", "-u");
+            var (groupId, _, _) = await _processService.RunAndCaptureAsync("id", "-g");
+            actionsImporterArguments.Add($"-e USER_ID={userId.TrimEnd()}");
+            actionsImporterArguments.Add($"-e GROUP_ID={groupId.TrimEnd()}");
         }
         actionsImporterArguments.Add($"-v \"{Directory.GetCurrentDirectory()}\":/data");
         actionsImporterArguments.Add($"{server}/{image}:{version}");
         actionsImporterArguments.AddRange(arguments);
 
-        return _processService.RunAsync(
+        await _processService.RunAsync(
             "docker",
             string.Join(' ', actionsImporterArguments),
             Directory.GetCurrentDirectory(),

--- a/src/ActionsImporter/Services/RuntimeService.cs
+++ b/src/ActionsImporter/Services/RuntimeService.cs
@@ -1,0 +1,10 @@
+﻿
+using System.Runtime.InteropServices;
+using ActionsImporter.Interfaces;
+
+namespace ActionsImporter.Services;
+
+public class RuntimeService : IRuntimeService
+{
+    public bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+}


### PR DESCRIPTION
## What's changing?
* Forwards two new environment variables to the docker image when on Linux operating systems
    * The actions importer CLI recognizes these variables and will change ownership of the given output directory to the user's id and group id

## How's this tested?
* Unit tests
* Additional validation performed internally against importer-labs

Fixes #23
