### PR TITLE
Implement a --prerelease global option

### DIFF
--- a/src/ActionsImporter.UnitTests/AppTests.cs
+++ b/src/ActionsImporter.UnitTests/AppTests.cs
@@ -39,7 +39,7 @@ public class AppTests
     public async Task CheckForUpdates_NoUpdatesNeeded(string? latestImage, string? currentImage, string result)
     {
         // Arrange
-        var image = "actions-importer/cli";
+        var image = "actions-importer/cli:latest";
         var server = "ghcr.io";
 
         using var stringWriter = new StringWriter();

--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -465,13 +465,13 @@ public class DockerServiceTests
     public async Task GetCurrentImageDigest_ParsesDigestCorrectly()
     {
         // Arrange
-        var image = "actions-importer/cli";
+        var image = "actions-importer/cli:latest";
         var server = "ghcr.io";
 
         _processService.Setup(handler =>
             handler.RunAndCaptureAsync(
                 "docker",
-                $"image inspect --format={{{{.Id}}}} {server}/{image}:latest",
+                $"image inspect --format={{{{.Id}}}} {server}/{image}",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
                 It.IsAny<bool>(),
@@ -491,7 +491,7 @@ public class DockerServiceTests
     public async Task GetLatestImageDigest_ParsesDigestCorrectly()
     {
         // Arrange
-        var image = "actions-importer/cli";
+        var image = "actions-importer/cli:latest";
         var server = "ghcr.io";
         var manifestResult = @"
 {
@@ -554,7 +554,7 @@ public class DockerServiceTests
         _processService.Setup(handler =>
             handler.RunAndCaptureAsync(
                 "docker",
-                $"manifest inspect {server}/{image}:latest",
+                $"manifest inspect {server}/{image}",
                 It.IsAny<string?>(),
                 It.IsAny<IEnumerable<(string, string)>?>(),
                 It.IsAny<bool>(),

--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -434,7 +434,7 @@ public class DockerServiceTests
         ).Returns(Task.CompletedTask);
 
         // Act, Assert
-        Assert.DoesNotThrowAsync(() => _dockerService.VerifyImagePresentAsync(image, server, version));
+        Assert.DoesNotThrowAsync(() => _dockerService.VerifyImagePresentAsync(image, server, version, false));
         _processService.VerifyAll();
     }
 
@@ -457,7 +457,7 @@ public class DockerServiceTests
         ).ThrowsAsync(new Exception());
 
         // Act, Assert
-        Assert.ThrowsAsync<Exception>(() => _dockerService.VerifyImagePresentAsync(image, server, version));
+        Assert.ThrowsAsync<Exception>(() => _dockerService.VerifyImagePresentAsync(image, server, version, false));
         _processService.VerifyAll();
     }
 

--- a/src/ActionsImporter/App.cs
+++ b/src/ActionsImporter/App.cs
@@ -75,7 +75,7 @@ public class App
     {
         var (standardOutput, standardError, exitCode) = await _processService.RunAndCaptureAsync("gh", "version");
         var ghActionsImporterVersion = await _processService.RunAndCaptureAsync("gh", "extension list");
-        var actionsImporterVersion = await _processService.RunAndCaptureAsync("docker", $"run --rm {ImageName} version", throwOnError: false);
+        var actionsImporterVersion = await _processService.RunAndCaptureAsync("docker", $"run --rm {ActionsImporterContainerRegistry}/{ImageName} version", throwOnError: false);
 
         var formattedGhVersion = standardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
         var formattedGhActionsImporterVersion = ghActionsImporterVersion.standardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)

--- a/src/ActionsImporter/App.cs
+++ b/src/ActionsImporter/App.cs
@@ -58,7 +58,8 @@ public class App
         await _dockerService.VerifyImagePresentAsync(
             ActionsImporterImage,
             ActionsImporterContainerRegistry,
-            ImageTag
+            ImageTag,
+            IsPrerelease
         ).ConfigureAwait(false);
 
         await _dockerService.ExecuteCommandAsync(

--- a/src/ActionsImporter/App.cs
+++ b/src/ActionsImporter/App.cs
@@ -12,6 +12,12 @@ public class App
     private readonly IProcessService _processService;
     private readonly IConfigurationService _configurationService;
 
+    public bool IsPrerelease { get; set; }
+
+    private string ImageTag => IsPrerelease ? "pre" : "latest";
+
+    private string ImageName => $"{ActionsImporterImage}:{ImageTag}";
+
     public App(IDockerService dockerService, IProcessService processService, IConfigurationService configurationService)
     {
         _dockerService = dockerService;
@@ -37,7 +43,7 @@ public class App
         await _dockerService.UpdateImageAsync(
             ActionsImporterImage,
             ActionsImporterContainerRegistry,
-            "latest",
+            ImageTag,
             username,
             password,
             passwordStdin
@@ -52,13 +58,13 @@ public class App
         await _dockerService.VerifyImagePresentAsync(
             ActionsImporterImage,
             ActionsImporterContainerRegistry,
-            "latest"
+            ImageTag
         ).ConfigureAwait(false);
 
         await _dockerService.ExecuteCommandAsync(
             ActionsImporterImage,
             ActionsImporterContainerRegistry,
-            "latest",
+            ImageTag,
             args.Select(x => x.EscapeIfNeeded()).ToArray()
         );
         return 0;
@@ -68,7 +74,7 @@ public class App
     {
         var (standardOutput, standardError, exitCode) = await _processService.RunAndCaptureAsync("gh", "version");
         var ghActionsImporterVersion = await _processService.RunAndCaptureAsync("gh", "extension list");
-        var actionsImporterVersion = await _processService.RunAndCaptureAsync("docker", $"run --rm {ActionsImporterContainerRegistry}/{ActionsImporterImage}:latest version", throwOnError: false);
+        var actionsImporterVersion = await _processService.RunAndCaptureAsync("docker", $"run --rm {ImageName} version", throwOnError: false);
 
         var formattedGhVersion = standardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault();
         var formattedGhActionsImporterVersion = ghActionsImporterVersion.standardOutput.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -77,7 +83,7 @@ public class App
 
         Console.WriteLine(formattedGhVersion);
         Console.WriteLine(formattedGhActionsImporterVersion);
-        Console.WriteLine($"actions-importer/cli\t{formattedActionsImporterVersion}");
+        Console.WriteLine($"actions-importer/cli:{ImageTag}\t{formattedActionsImporterVersion}");
 
         return 0;
     }
@@ -86,8 +92,8 @@ public class App
     {
         try
         {
-            var latestImageDigestTask = _dockerService.GetLatestImageDigestAsync(ActionsImporterImage, ActionsImporterContainerRegistry);
-            var currentImageDigestTask = _dockerService.GetCurrentImageDigestAsync(ActionsImporterImage, ActionsImporterContainerRegistry);
+            var latestImageDigestTask = _dockerService.GetLatestImageDigestAsync(ImageName, ActionsImporterContainerRegistry);
+            var currentImageDigestTask = _dockerService.GetCurrentImageDigestAsync(ImageName, ActionsImporterContainerRegistry);
 
             await Task.WhenAll(latestImageDigestTask, currentImageDigestTask);
 

--- a/src/ActionsImporter/Commands/Common.cs
+++ b/src/ActionsImporter/Commands/Common.cs
@@ -6,6 +6,12 @@ namespace ActionsImporter.Commands;
 public static class Common
 {
 
+    public static readonly Option<bool> Prerelease = new("--prerelease")
+    {
+        Description = "Use prerelease image for GitHub Actions Importer",
+        IsRequired = false,
+    };
+
     public static Command AppendTransformerOptions(this Command command)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -73,6 +79,15 @@ public static class Common
         return command;
     }
 
+    public static Command AppendPrereleaseOption(this Command command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        command.AddGlobalOption(Prerelease);
+
+        return command;
+    }
+
     public static Command AppendGeneralOptions(this Command command)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -104,6 +119,8 @@ public static class Common
                 Description = "Disable caching of http responses."
             }
         );
+
+        command.AddGlobalOption(Prerelease);
 
         return command;
     }

--- a/src/ActionsImporter/Commands/ContainerCommand.cs
+++ b/src/ActionsImporter/Commands/ContainerCommand.cs
@@ -10,7 +10,8 @@ public abstract class ContainerCommand : BaseCommand
 
     protected ContainerCommand(string[] args)
     {
-        _args = args;
+        // Don't forward the --prerelease flag to GitHub Actions Importer image
+        _args = args.Where(arg => !arg.Contains(Common.Prerelease.Name, StringComparison.Ordinal)).ToArray();
     }
 
     protected abstract ImmutableArray<Option> Options { get; }

--- a/src/ActionsImporter/Commands/Update.cs
+++ b/src/ActionsImporter/Commands/Update.cs
@@ -33,6 +33,7 @@ public class Update : BaseCommand
         command.AddOption(UsernameOption);
         command.AddOption(PasswordOption);
         command.AddOption(PasswordStdInOption);
+        command.AppendPrereleaseOption();
 
         command.Handler = CommandHandler.Create((string? username, string? password, bool passwordStdin) => app.UpdateActionsImporterAsync(username, password, passwordStdin));
 

--- a/src/ActionsImporter/Commands/Version.cs
+++ b/src/ActionsImporter/Commands/Version.cs
@@ -14,6 +14,8 @@ public class Version : BaseCommand
 
         var command = base.GenerateCommand(app);
 
+        command.AppendPrereleaseOption();
+
         command.Handler = CommandHandler.Create(app.GetVersionAsync);
 
         return command;

--- a/src/ActionsImporter/Interfaces/IDockerService.cs
+++ b/src/ActionsImporter/Interfaces/IDockerService.cs
@@ -8,7 +8,7 @@ public interface IDockerService
 
     Task VerifyDockerRunningAsync();
 
-    Task VerifyImagePresentAsync(string image, string server, string version);
+    Task VerifyImagePresentAsync(string image, string server, string version, bool isPrerelease);
 
     Task<string?> GetLatestImageDigestAsync(string image, string server);
 

--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -43,6 +43,9 @@ var parser = new CommandLineBuilder(command)
     .CancelOnProcessTermination()
     .Build();
 
+
+app.IsPrerelease = parser.Parse(args).HasOption(Common.Prerelease);
+
 try
 {
     if (!Array.Exists(args, x => x == "update"))

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -84,8 +84,10 @@ public class DockerService : IDockerService
         }
     }
 
-    public async Task VerifyImagePresentAsync(string image, string server, string version)
+    public async Task VerifyImagePresentAsync(string image, string server, string version, bool isPrerelease)
     {
+        var imageName = $"{server}/{image}:{version}";
+        var preReleaseOption = isPrerelease ? " --prerelease" : string.Empty;
         try
         {
             await _processService.RunAsync(
@@ -94,9 +96,10 @@ public class DockerService : IDockerService
                 output: false
             );
         }
+
         catch (Exception)
         {
-            throw new Exception("Unable to locate GitHub Actions Importer image locally. Please run `gh actions-importer update` to fetch the latest image prior to running this command.");
+            throw new Exception($"Unable to locate {imageName} image locally. Please run `gh actions-importer update{preReleaseOption}` to fetch the latest image prior to running this command.");
         }
     }
 

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -102,7 +102,7 @@ public class DockerService : IDockerService
 
     public async Task<string?> GetLatestImageDigestAsync(string image, string server)
     {
-        var (standardOutput, _, _) = await _processService.RunAndCaptureAsync("docker", $"manifest inspect {server}/{image}:latest");
+        var (standardOutput, _, _) = await _processService.RunAndCaptureAsync("docker", $"manifest inspect {server}/{image}");
         Manifest? manifest = JsonSerializer.Deserialize<Manifest>(standardOutput);
 
         return manifest?.GetDigest();
@@ -110,7 +110,7 @@ public class DockerService : IDockerService
 
     public async Task<string?> GetCurrentImageDigestAsync(string image, string server)
     {
-        var (standardOutput, _, _) = await _processService.RunAndCaptureAsync("docker", $"image inspect --format={{{{.Id}}}} {server}/{image}:latest");
+        var (standardOutput, _, _) = await _processService.RunAndCaptureAsync("docker", $"image inspect --format={{{{.Id}}}} {server}/{image}");
 
         return standardOutput.Split(":").ElementAtOrDefault(1)?.Trim();
     }


### PR DESCRIPTION
## What's changing?
* Adds a flag `--prerelease` for all options which will use the `:pre` tagged Docker image.
    * This assists with testing preview changes, such as major version upgrades. 

## How's this tested?
* Unit tests
* I ran thru the commands to check that the `--prerelease` command is present and supported
  * If reviewers could try `update --prerelease` and `version --prerelease` options as well, that'd be great! 

Closes github/valet#5280
