### PR TITLE
Fix CI lint error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
       - name: install dotnet-format
         run: dotnet tool install -g dotnet-format --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
       - name: lint
-        run: dotnet format src/ActionsImporter.sln --verify-no-changes
+        working-directory: src
+        run: dotnet format ActionsImporter.sln --verify-no-changes
 
   unit-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What's changing?

There seems to be an incompatibility between .NET versions when running `dotnet format`. Running the command inside the `src` directory works around the issue by forcing the CLI to use the same version defined in the `src/global.json` file.

## How's this tested?

By running the CI workflow
