### PR TITLE
Add feedback link to main help menu

### DIFF
--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -15,7 +15,11 @@ var app = new App(
     new ConfigurationService()
 );
 
-var command = new RootCommand("GitHub Actions Importer is a tool to help plan and automate your migration to Actions.")
+string welcomeMessage = @"GitHub Actions Importer helps you plan, test, and automate your migration to GitHub Actions.
+
+Please share your feedback @ https://gh.io/ghaimporterfeedback";
+
+var command = new RootCommand(welcomeMessage)
 {
     new Update().Command(app),
     new Version().Command(app),
@@ -31,8 +35,8 @@ var parser = new CommandLineBuilder(command)
     {
         ctx.HelpBuilder.CustomizeLayout(_ =>
             HelpBuilder.Default
-                .GetLayout()
-                .Skip(2)
+              .GetLayout()
+              .Where((_, i) => i != 1) // Remove the usage section (second item in the help layout)
             );
     })
     .UseEnvironmentVariableDirective()


### PR DESCRIPTION
## What's changing?
Adds the feedback board link only to the root help menu.

This also re-enables all of the descriptions for each command at the top
of the command or sub-command help menu. There was a commit a ways back that [removed descriptions](https://github.com/github/gh-actions-importer/commit/12cd38deb2ecdc9d488675b427d8d6bf4531e729) _along with usage_ from all the commands. The removal of the `usage` command was correct, since that spits out the dotnet cli command (not the `gh` cli extension one), but the descriptions shouldn't have been removed.

The usage command is the second item in the enumerable custom help builder, so I updated that to just remove the second element (the usage one) and bring back the description.

![Screenshot 2023-02-27 at 13 07 07](https://user-images.githubusercontent.com/13201458/221658995-7251c0af-bb8a-4ec3-97c6-63b31b899ea4.png)


## How's this tested?
Run `dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- --help` to see the updated description/message at the top of the output.

All other commands will _also_ now have their description again. e.g. run `dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- migrate azure-devops` to see that description (doesn't contain a feedback link).

Closes github/valet#5532
