### PR TITLE
Update docs to deprecate set-output usage

### DIFF
--- a/docs/circle_ci/Orbs/Docker/Check.md
+++ b/docs/circle_ci/Orbs/Docker/Check.md
@@ -47,7 +47,7 @@ runs:
   - id: release_tag
     run: |-
       RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w %{url_effective} 'https://github.com/docker/docker-credential-helpers/releases/latest' | sed 's:.*/::')
-      echo ::set-output name=release_tag::$RELEASE_VERSION
+      echo "release_tag=$RELEASE_VERSION" >> $GITHUB_OUTPUT
     if: "${{ fromJSON(inputs.use-docker-credentials-store) }}"
     shell: bash
   - run: |-
@@ -117,7 +117,7 @@ jobs:
     - id: release_tag
       run: |-
         RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w %{url_effective} 'https://github.com/docker/docker-credential-helpers/releases/latest' | sed 's:.*/::')
-        echo ::set-output name=release_tag::$RELEASE_VERSION
+        echo "release_tag=$RELEASE_VERSION" >> $GITHUB_OUTPUT
     - run: |-
         HELPER_FILENAME="docker-credential-${{ env.HELPER_NAME }}"
         if which "$HELPER_FILENAME" > /dev/null 2>&1; then

--- a/docs/circle_ci/Orbs/Docker/InstallDockerCredentialHelper.md
+++ b/docs/circle_ci/Orbs/Docker/InstallDockerCredentialHelper.md
@@ -20,7 +20,7 @@ jobs:
 - id: release_tag
   run: |-
     RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w %{url_effective} 'https://github.com/docker/docker-credential-helpers/releases/latest' | sed 's:.*/::')
-    echo ::set-output name=release_tag::$RELEASE_VERSION
+    echo "release_tag=$RELEASE_VERSION"  >> $GITHUB_OUTPUT
 - run: |-
     HELPER_FILENAME="docker-credential-${{ env.HELPER_NAME }}"
     if which "$HELPER_FILENAME" > /dev/null 2>&1; then

--- a/docs/circle_ci/Orbs/Docker/InstallDockerize.md
+++ b/docs/circle_ci/Orbs/Docker/InstallDockerize.md
@@ -37,7 +37,7 @@ runs:
   - id: version
     run: |-
       DOCKERIZE_VERSION=$(curl --fail --retry 3 -Ls -o /dev/null -w %{url_effective} 'https://github.com/jwilder/dockerize/releases/latest' | sed 's:.*/::')
-      echo ::set-output name=version::$DOCKERIZE_VERSION
+      echo "version=$DOCKERIZE_VERSION" >> $GITHUB_OUTPUT
     shell: bash
   - run: |-
       if [[ $VERSION == "latest" ]]; then VERSION="${{ steps.version.outputs.version }}"; fi
@@ -58,7 +58,7 @@ steps:
 - id: version
   run: |-
     DOCKERIZE_VERSION=$(curl --fail --retry 3 -Ls -o /dev/null -w %{url_effective} 'https://github.com/jwilder/dockerize/releases/latest' | sed 's:.*/::')
-    echo ::set-output name=version::$DOCKERIZE_VERSION
+    echo "version=$DOCKERIZE_VERSION" >> $GITHUB_OUTPUT
 - run: |-
     if [[ $VERSION == "latest" ]]; then VERSION="${{ steps.version.outputs.version }}"; fi
     curl -O --silent --show-error --location --fail --retry 3 "https://github.com/jwilder/dockerize/releases/download/$VERSION/dockerize-linux-amd64-$VERSION.tar.gz"

--- a/docs/circle_ci/Orbs/Docker/Publish.md
+++ b/docs/circle_ci/Orbs/Docker/Publish.md
@@ -44,7 +44,7 @@ workflows:
 - id: release_tag
   run: |-
     RELEASE_VERSION=$(curl -Ls --fail --retry 3 -o /dev/null -w %<url_effective>s 'https://github.com/docker/docker-credential-helpers/releases/latest' | sed 's:.*/::')
-    echo ::set-output name=release_tag::$RELEASE_VERSION
+    echo "release_tag=$RELEASE_VERSION" >> $GITHUB_OUTPUT
 - run: |-
     curl -L -o '${{ env.HELPER_FILENAME }}_archive' 'https://github.com/docker/docker-credential-helpers/releases/download/${{ env.RELEASE_TAG }}/${{ env.HELPER_FILENAME }}-${{ env.RELEASE_TAG }}-amd64.tar.gz'
     tar xvf './${{ env.HELPER_FILENAME }}_archive'

--- a/docs/circle_ci/Orbs/Node/InstallPackages.md
+++ b/docs/circle_ci/Orbs/Node/InstallPackages.md
@@ -21,7 +21,7 @@ jobs:
 
 ```yaml
 - id: yarn-cache-dir-path
-  run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+  run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v2
   with:
     path: "${{ steps.yarn-cache-dir-path.outputs.dir }}"

--- a/docs/circle_ci/Orbs/Node/Run.md
+++ b/docs/circle_ci/Orbs/Node/Run.md
@@ -22,7 +22,7 @@ workflows:
 ```yaml
 - uses: actions/checkout@v2
 - id: npm-cache-dir
-  run: echo '::set-output name=dir::$(npm config get cache)'
+  run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v2
   with:
     path: "${{ steps.npm-cache-dir.outputs.dir }}"

--- a/docs/circle_ci/Orbs/Node/Test.md
+++ b/docs/circle_ci/Orbs/Node/Test.md
@@ -22,7 +22,7 @@ workflows:
 ```yaml
 - uses: actions/checkout@v2
 - id: npm-cache-dir
-  run: echo '::set-output name=dir::$(npm config get cache)'
+  run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v2
   with:
     path: "${{ steps.npm-cache-dir.outputs.dir }}"

--- a/docs/circle_ci/Orbs/Python/InstallPackages.md
+++ b/docs/circle_ci/Orbs/Python/InstallPackages.md
@@ -25,7 +25,7 @@ jobs:
 ```yaml
 - name: Get python version
   id: python-version
-  run: echo '::set-output name=python-version::$(python -v)'
+  run: echo "python-version=$(python -v)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v2
   with:
     key: "${{ runner.os }}-${{ github.ref }}-python-${{ steps.python-version.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}"

--- a/docs/circle_ci/Orbs/Python/Test.md
+++ b/docs/circle_ci/Orbs/Python/Test.md
@@ -23,7 +23,7 @@ jobs:
 - uses: actions/checkout@v2
 - name: Get python version
   id: python-version
-  run: echo '::set-output name=python-version::$(python -v)'
+  run: echo "python-version=$(python -v)" >> $GITHUB_OUTPUT
 - uses: actions/cache@v2
   with:
     key: "${{ runner.os }}-${{ github.ref }}-python-${{ steps.python-version.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}"

--- a/docs/circle_ci/Orbs/Slack/Notify.md
+++ b/docs/circle_ci/Orbs/Slack/Notify.md
@@ -55,7 +55,7 @@ runs:
     shell: bash
     run: |-
       if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.BRANCH_PATTERN }} ]]; then
-        echo ::set-output name=match::true
+        echo "match=true" >> $GITHUB_OUTPUT
       fi
     env:
       VALUE_TO_MATCH: "${{ github.ref }}"
@@ -64,7 +64,7 @@ runs:
     shell: bash
     run: |-
       if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.TAG_PATTERN }} ]]; then
-        echo ::set-output name=match::true
+        echo "match=true" >> $GITHUB_OUTPUT
       fi
     env:
       VALUE_TO_MATCH: "${{ github.ref }}"
@@ -83,7 +83,7 @@ steps:
   shell: bash
   run: |-
     if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.BRANCH_PATTERN }} ]]; then
-      echo ::set-output name=match::true
+      echo "match=true" >> $GITHUB_OUTPUT
     fi
   env:
     VALUE_TO_MATCH: "${{ github.ref }}"
@@ -92,7 +92,7 @@ steps:
   shell: bash
   run: |-
     if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.TAG_PATTERN }} ]]; then
-      echo ::set-output name=match::true
+      echo "match=true" >> $GITHUB_OUTPUT
     fi
   env:
     VALUE_TO_MATCH: "${{ github.ref }}"

--- a/docs/circle_ci/Orbs/Slack/OnHold.md
+++ b/docs/circle_ci/Orbs/Slack/OnHold.md
@@ -47,7 +47,7 @@ runs:
     shell: bash
     run: |-
       if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.BRANCH_PATTERN }} ]]; then
-        echo ::set-output name=match::true
+        echo "match=true" >> $GITHUB_OUTPUT
       fi
     env:
       VALUE_TO_MATCH: "${{ github.ref }}"
@@ -56,7 +56,7 @@ runs:
     shell: bash
     run: |-
       if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.TAG_PATTERN }} ]]; then
-        echo ::set-output name=match::true
+        echo "match=true" >> $GITHUB_OUTPUT
       fi
     env:
       VALUE_TO_MATCH: "${{ github.ref }}"
@@ -75,7 +75,7 @@ steps:
   shell: bash
   run: |-
     if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.BRANCH_PATTERN }} ]]; then
-      echo ::set-output name=match::true
+      echo "match=true" >> $GITHUB_OUTPUT
     fi
   env:
     VALUE_TO_MATCH: "${{ github.ref }}"
@@ -84,7 +84,7 @@ steps:
   shell: bash
   run: |-
     if [[ '${{ env.VALUE_TO_MATCH }}' =~ ${{ env.TAG_PATTERN }} ]]; then
-      echo ::set-output name=match::true
+      echo "match=true" >> $GITHUB_OUTPUT
     fi
   env:
     VALUE_TO_MATCH: "${{ github.ref }}"

--- a/docs/jenkins/Post.md
+++ b/docs/jenkins/Post.md
@@ -67,7 +67,7 @@ jobs:
     steps:
       ...
       - name: snapshot post build job status
-        run: echo "::set-output name=aborted=${{ job.status == 'cancelled' }}"
+        run: echo "aborted=${{ job.status == 'cancelled' }}" >> $GITHUB_OUTPUT
         id: __post_build
       - name: powershell
         shell: powershell
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: snapshot post build workflow status
         run: |-
-          echo "::set-output name=aborted=${{ contains(needs.*.result,'cancelled') }}"
+          echo "aborted=${{ contains(needs.*.result,'cancelled') }}" >> $GITHUB_OUTPUT
         id: __post_build
       - name: echo message
         run: echo I will run if worfklow was aborted

--- a/docs/travis_ci/Cache/Yarn.md
+++ b/docs/travis_ci/Cache/Yarn.md
@@ -12,7 +12,7 @@ cache:
 ```yaml
 - name: Get yarn cache directory path
   id: yarn-cache-dir-path
-  run: echo '::set-output name=dir::$(yarn cache dir)'
+  run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 - name: Set up yarn cache
   uses: actions/cache@v2
   with:


### PR DESCRIPTION
## What's changing?

All code changes have been deployed already, and this change updates the public facing transformer docs to not reference the `set-output` workflow command.

## How's this tested?

:eyes:

