### PR TITLE
Add docs for multi-project pipelines

### DIFF
--- a/docs/gitlab/Trigger.md
+++ b/docs/gitlab/Trigger.md
@@ -1,0 +1,33 @@
+# Trigger
+
+## Parent child pipelines
+
+```yaml
+trigger:
+  include:
+  - local: path/to/child-pipeline.yml
+```
+
+### Transformed Github Action
+
+The job graph of the included files is merged with the job graph of the calling workflow.
+
+## Multi-project pipelines
+
+```yaml
+trigger:
+  "org/repo"
+```
+
+### Transformed Github Action
+
+```yml
+- name: Run downstream workflow
+  run: gh workflow run $WORKFLOW_FILE --repo org/repo
+  env:
+    WORKFLOW_FILE: UPDATE_ME
+```
+
+### Unsupported Options
+
+None

--- a/docs/gitlab/Trigger.md
+++ b/docs/gitlab/Trigger.md
@@ -8,7 +8,7 @@ trigger:
   - local: path/to/child-pipeline.yml
 ```
 
-### Transformed Github Action
+### Transformed GitHub action
 
 The job graph of the included files is merged with the job graph of the calling workflow.
 
@@ -19,7 +19,7 @@ trigger:
   "org/repo"
 ```
 
-### Transformed Github Action
+### Transformed GitHub action
 
 ```yml
 - name: Run downstream workflow
@@ -28,6 +28,6 @@ trigger:
     WORKFLOW_FILE: UPDATE_ME
 ```
 
-### Unsupported Options
+### Unsupported options
 
 None

--- a/docs/gitlab/index.md
+++ b/docs/gitlab/index.md
@@ -17,6 +17,7 @@
 | [Services](Services.md)         | services                                   |
 | [Tags](Tags.md)                 | runs-on                                    |
 | [Timeout](Timeout.md)           | timeout-minutes                            |
+| [Trigger](Trigger.md)           | run                                        |
 
 The following constructs do not have an equivalent in GitHub Actions:
 


### PR DESCRIPTION
## What's changing?

This adds transformer docs for the GitLab `trigger` tag

## How's this tested?

:eyes:
