### PR TITLE
Add experimental flag to bypass arg validation

### DIFF
--- a/src/ActionsImporter/Commands/Common.cs
+++ b/src/ActionsImporter/Commands/Common.cs
@@ -12,6 +12,13 @@ public static class Common
         IsRequired = false,
     };
 
+    public static readonly Option<bool> Experimental = new("--experimental")
+    {
+        Description = "Enable experimental and unsupported features.",
+        IsRequired = false,
+        IsHidden = true
+    };
+
     public static Command AppendTransformerOptions(this Command command)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -119,6 +126,8 @@ public static class Common
                 Description = "Disable caching of http responses."
             }
         );
+
+        command.AddGlobalOption(Experimental);
 
         command.AddGlobalOption(Prerelease);
 

--- a/src/ActionsImporter/Models/ParserExtensions.cs
+++ b/src/ActionsImporter/Models/ParserExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.CommandLine.Parsing;
+using ActionsImporter.Commands;
+
+namespace ActionsImporter.Models;
+
+public static class ParserExtensions
+{
+    public static async Task<int> InvokeAsync(this Parser? parser, App? app, string[] args, bool experimental)
+    {
+        ArgumentNullException.ThrowIfNull(parser);
+        ArgumentNullException.ThrowIfNull(app);
+
+        if (experimental)
+        {
+            Console.WriteLine("Experimental features are enabled. Use at your own risk.");
+
+            await app.ExecuteActionsImporterAsync(args.Where(arg => !arg.Contains(Common.Experimental.Name, StringComparison.Ordinal)).ToArray());
+            return 0;
+        }
+
+        return await parser.InvokeAsync(args);
+    }
+}

--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -4,6 +4,7 @@ using System.CommandLine.Help;
 using System.CommandLine.Parsing;
 using ActionsImporter;
 using ActionsImporter.Commands;
+using ActionsImporter.Models;
 using ActionsImporter.Services;
 using Version = ActionsImporter.Commands.Version;
 
@@ -47,8 +48,8 @@ var parser = new CommandLineBuilder(command)
     .CancelOnProcessTermination()
     .Build();
 
-
-app.IsPrerelease = parser.Parse(args).HasOption(Common.Prerelease);
+var parsedArguments = parser.Parse(args);
+app.IsPrerelease = parsedArguments.HasOption(Common.Prerelease);
 
 try
 {
@@ -56,7 +57,8 @@ try
     {
         await app.CheckForUpdatesAsync();
     }
-    await parser.InvokeAsync(args);
+
+    await parser.InvokeAsync(app, args, parsedArguments.HasOption(Common.Experimental));
     return 0;
 }
 catch (Exception e)


### PR DESCRIPTION
## What's changing?

This adds an `--experimental` flag to CLI commands to bypass command line validation in the c# frontend. This will enable users to send unpublished CLI commands/arguments to the docker image to test out experimental features.

## How's this tested?

```bash
$ dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- command --doesnt-exist --experimental
```
