### PR TITLE
Add list-features, --enable-features, & --disable-features

### DIFF
--- a/src/ActionsImporter/Commands/Common.cs
+++ b/src/ActionsImporter/Commands/Common.cs
@@ -70,7 +70,7 @@ public static class Common
         command.AddGlobalOption(
             new Option<string[]>(new[] { "--enable-features" })
             {
-                Description = "A list of features by name to disable by name. Use `gh actions-importer list-features` to see available features.",
+                Description = "A list of features to enable by name. Use `gh actions-importer list-features` to see available features.",
                 IsRequired = false,
                 AllowMultipleArgumentsPerToken = true
             }

--- a/src/ActionsImporter/Commands/Common.cs
+++ b/src/ActionsImporter/Commands/Common.cs
@@ -63,7 +63,25 @@ public static class Common
         command.AddGlobalOption(
             new Option<string>(new[] { "--features" })
             {
-                Description = "Features to enable in transformed workflows."
+                Description = "GHES features to enable in transformed workflows."
+            }
+        );
+
+        command.AddGlobalOption(
+            new Option<string[]>(new[] { "--enable-features" })
+            {
+                Description = "A list of features by name to disable by name. Use `gh actions-importer list-features` to see available features.",
+                IsRequired = false,
+                AllowMultipleArgumentsPerToken = true
+            }
+        );
+
+        command.AddGlobalOption(
+            new Option<string[]>(new[] { "--disable-features" })
+            {
+                Description = "A list of features to disable by name. Use `gh actions-importer list-features` to see available features.",
+                IsRequired = false,
+                AllowMultipleArgumentsPerToken = true
             }
         );
 

--- a/src/ActionsImporter/Commands/ListFeatures.cs
+++ b/src/ActionsImporter/Commands/ListFeatures.cs
@@ -10,7 +10,7 @@ public class ListFeatures : ContainerCommand
     }
 
     protected override string Name => "list-features";
-    protected override string Description => "List the available feature flags for Actions Importer.";
+    protected override string Description => "List the available feature flags for GitHub Actions Importer.";
 
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>();
 }

--- a/src/ActionsImporter/Commands/ListFeatures.cs
+++ b/src/ActionsImporter/Commands/ListFeatures.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Immutable;
+using System.CommandLine;
+
+namespace ActionsImporter.Commands;
+
+public class ListFeatures : ContainerCommand
+{
+    public ListFeatures(string[] args) : base(args)
+    {
+    }
+
+    protected override string Name => "list-features";
+    protected override string Description => "List the available feature flags for Actions Importer.";
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>();
+}

--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -28,7 +28,8 @@ var command = new RootCommand(welcomeMessage)
     new Audit(args).Command(app),
     new Forecast(args).Command(app),
     new DryRun(args).Command(app),
-    new Migrate(args).Command(app)
+    new Migrate(args).Command(app),
+    new ListFeatures(args).Command(app)
 };
 
 var parser = new CommandLineBuilder(command)


### PR DESCRIPTION
## What's changing?
* Adds public facing commands for customers to interact with customer facing feature flags.
* _Note_ This interface is a little clunky atm, but not many customers use `--features` atm. There is follow-up work to investigate storing this in a credentials file and/or as env variables.

## How's this tested?
* Specs
* Running some commands locally:
    * **Note** You will need to pull the latest docker image before running these commands 
    * `dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- list-features`
    * `dotnet run --project src/ActionsImporter/ActionsImporter.csproj --  dry-run circle-ci -o tmp/circle --source-file-path tmp/config.yml --circle-ci-project rails-demo --disable-features=workflow-concurrency-option-allowed actions/cache`
      * This should result in an output file that comments out the caching actions syntax

Here's a circle CI config you can use for testing:
```yaml
version: 2.1

orbs:
  ruby: circleci/ruby@1.1.0
  node: circleci/node@2

jobs:
  build:
    docker:
      - image: cimg/ruby:2.7.5-node
    steps:
      - checkout
      - ruby/install-deps
      # Store bundle cache
      - node/install-packages:
          pkg-manager: yarn
          cache-key: "yarn.lock"

workflows:
  version: 2
  build_and_test:
    jobs:
      - build
```

Closes github/valet#5714
