### PR TITLE
Update configure command to support configuring feature flags

### DIFF
--- a/src/ActionsImporter.UnitTests/Models/FeatureTests.cs
+++ b/src/ActionsImporter.UnitTests/Models/FeatureTests.cs
@@ -21,8 +21,8 @@ public class FeatureTests
     [Test]
     public void Initialize()
     {
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        Feature? feature = JsonSerializer.Deserialize<Feature>(featureResult, options);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, };
+        var feature = JsonSerializer.Deserialize<Feature>(featureResult, options);
 
         Assert.AreEqual("actions/cache", feature?.Name);
         Assert.AreEqual("Control usage of actions/cache inside of workflows. Outputs a comment if not enabled.", feature?.Description);
@@ -35,7 +35,7 @@ public class FeatureTests
     {
         var enabledFeature = new Feature
         {
-            Enabled = true
+            Enabled = true,
         };
         Assert.AreEqual("enabled", enabledFeature.EnabledMessage());
     }
@@ -45,7 +45,7 @@ public class FeatureTests
     {
         var disabledFeature = new Feature
         {
-            Enabled = false
+            Enabled = false,
         };
         Assert.AreEqual("disabled", disabledFeature.EnabledMessage());
 

--- a/src/ActionsImporter.UnitTests/Models/FeatureTests.cs
+++ b/src/ActionsImporter.UnitTests/Models/FeatureTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Text.Json;
+using ActionsImporter.Models;
+using NUnit.Framework;
+
+namespace ActionsImporter.UnitTests.Models;
+
+[TestFixture]
+public class FeatureTests
+{
+    private readonly string featureResult = @"
+  {
+    ""name"": ""actions/cache"",
+    ""description"": ""Control usage of actions/cache inside of workflows. Outputs a comment if not enabled."",
+    ""enabled"": false,
+    ""ghes_version"": ""ghes-3.5"",
+    ""customer_facing"": true,
+    ""env_name"": ""FEATURE_ACTIONS_CACHE""
+  }
+    ";
+
+    [Test]
+    public void Initialize()
+    {
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        Feature? feature = JsonSerializer.Deserialize<Feature>(featureResult, options);
+
+        Assert.AreEqual("actions/cache", feature?.Name);
+        Assert.AreEqual("Control usage of actions/cache inside of workflows. Outputs a comment if not enabled.", feature?.Description);
+        Assert.AreEqual("FEATURE_ACTIONS_CACHE", feature?.EnvName);
+        Assert.IsFalse(feature?.Enabled);
+    }
+
+    [Test]
+    public void EnabledMessage()
+    {
+        var enabledFeature = new Feature
+        {
+            Enabled = true
+        };
+        Assert.AreEqual("enabled", enabledFeature.EnabledMessage());
+    }
+
+    [Test]
+    public void DisabledMessage()
+    {
+        var disabledFeature = new Feature
+        {
+            Enabled = false
+        };
+        Assert.AreEqual("disabled", disabledFeature.EnabledMessage());
+
+    }
+}

--- a/src/ActionsImporter.UnitTests/Services/ConfigurationServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/ConfigurationServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 using ActionsImporter.Interfaces;
+using ActionsImporter.Models;
 using ActionsImporter.Services;
 using NUnit.Framework;
 
@@ -71,9 +72,9 @@ public class ConfigurationServiceTests
         var filePath = Path.Combine(Path.GetTempPath(), "gh-actions-importer.tests", ".env.local");
         var directory = Path.GetDirectoryName(filePath)!;
 
-        var contents = @" 
+        var contents = @"
 USERNAME=mona
-PASSWORD=hunter2 
+PASSWORD=hunter2
 EMPTY=
 
 MALFORMED=TRUE=
@@ -96,5 +97,29 @@ WITH_QUOTES=""value""
 
         // Assert
         Assert.AreEqual(expectedResult, result);
+    }
+
+    [Test]
+    [Ignore("This test needs some sort of mock for Prompt")]
+    public Task GetFeaturesInput_ReturnsVariables()
+    {
+        // Arrange
+        var feature = new Feature
+        {
+            Name = "test",
+            EnvName = "FEATURE_TEST",
+            Enabled = false
+        };
+        var features = new List<Feature> { feature };
+
+        // Act
+        var result = _configurationService.GetFeaturesInput(features);
+
+        // Assert
+        ImmutableDictionary<string, string> expectedVars = ImmutableDictionary<string, string>.Empty
+            .Add("FEATURE_TEST", "true");
+        Assert.AreEqual(expectedVars, result);
+
+        return Task.CompletedTask;
     }
 }

--- a/src/ActionsImporter.UnitTests/Services/ConfigurationServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/ConfigurationServiceTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 using ActionsImporter.Interfaces;
-using ActionsImporter.Models;
 using ActionsImporter.Services;
 using NUnit.Framework;
 
@@ -72,9 +71,9 @@ public class ConfigurationServiceTests
         var filePath = Path.Combine(Path.GetTempPath(), "gh-actions-importer.tests", ".env.local");
         var directory = Path.GetDirectoryName(filePath)!;
 
-        var contents = @"
+        var contents = @" 
 USERNAME=mona
-PASSWORD=hunter2
+PASSWORD=hunter2 
 EMPTY=
 
 MALFORMED=TRUE=
@@ -97,29 +96,5 @@ WITH_QUOTES=""value""
 
         // Assert
         Assert.AreEqual(expectedResult, result);
-    }
-
-    [Test]
-    [Ignore("This test needs some sort of mock for Prompt")]
-    public Task GetFeaturesInput_ReturnsVariables()
-    {
-        // Arrange
-        var feature = new Feature
-        {
-            Name = "test",
-            EnvName = "FEATURE_TEST",
-            Enabled = false
-        };
-        var features = new List<Feature> { feature };
-
-        // Act
-        var result = _configurationService.GetFeaturesInput(features);
-
-        // Assert
-        ImmutableDictionary<string, string> expectedVars = ImmutableDictionary<string, string>.Empty
-            .Add("FEATURE_TEST", "true");
-        Assert.AreEqual(expectedVars, result);
-
-        return Task.CompletedTask;
     }
 }

--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -212,6 +212,15 @@ public class DockerServiceTests
         _processService.VerifyAll();
     }
 
+    // TODO: Add tests for GetFeaturesAsync
+    // public async Task GetFeaturesAsync_ReturnsFeatures()
+    // {
+    // }
+
+    // public async Task GetFeaturesAsync_BadJSONReturnsEmptyList()
+    // {
+    // }
+
     [Test]
     public void VerifyDockerRunningAsync_IsRunning_NoException()
     {

--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Threading.Tasks;
 using ActionsImporter.Interfaces;
+using ActionsImporter.Models;
 using ActionsImporter.Services;
 using Moq;
 using NUnit.Framework;
@@ -212,14 +214,79 @@ public class DockerServiceTests
         _processService.VerifyAll();
     }
 
-    // TODO: Add tests for GetFeaturesAsync
-    // public async Task GetFeaturesAsync_ReturnsFeatures()
-    // {
+    [Test]
+    public async Task GetFeaturesAsync_ReturnsFeatures()
+    {
+        // Arrange
+        var image = "actions-importer/cli";
+        var server = "ghcr.io";
+        var version = "latest";
+        var arguments = new[] { "list-features", "--json" };
+        var features = new List<Feature>
+      {
+        new Feature
+        {
+          Name = "actions/cache",
+          Description = "Control usage of actions/cache inside of workflows. Outputs a comment if not enabled.",
+          Enabled = false,
+          EnvName = "FEATURE_ACTIONS_CACHE"
+        },
+        new Feature
+        {
+          Name = "composite-actions",
+          Description = "Minimizes resulting workflow complexity through the use of composite actions. See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action for more information.",
+          Enabled = true,
+          EnvName = "FEATURE_COMPOSITE_ACTIONS"
+        }
+      };
+        var featuresJSON = JsonSerializer.Serialize(features);
+
+        _processService.Setup(handler =>
+            handler.RunAndCaptureAsync(
+                "docker",
+                $"run --rm -t {server}/{image}:{version} {string.Join(' ', arguments)}",
+                null,
+                null,
+                false,
+                null
+            )
+        ).Returns(Task.FromResult((featuresJSON, "", 0)));
+
+        // Act
+        var featuresResult = await _dockerService.GetFeaturesAsync(image, server, version);
+        var featuresResultJSON = JsonSerializer.Serialize(featuresResult);
+
+        // Assert
+        Assert.AreEqual(featuresJSON, featuresResultJSON);
+    }
     // }
 
-    // public async Task GetFeaturesAsync_BadJSONReturnsEmptyList()
-    // {
-    // }
+    [Test]
+    public async Task GetFeaturesAsync_BadJSONReturnsEmptyList()
+    {
+        // Arrange
+        var image = "actions-importer/cli";
+        var server = "ghcr.io";
+        var version = "latest";
+        var arguments = new[] { "list-features", "--json" };
+
+        _processService.Setup(handler =>
+            handler.RunAndCaptureAsync(
+                "docker",
+                $"run --rm -t {server}/{image}:{version} {string.Join(' ', arguments)}",
+                null,
+                null,
+                false,
+                null
+            )
+        ).Returns(Task.FromResult(("", "", 0)));
+
+        // Act
+        var featuresResult = await _dockerService.GetFeaturesAsync(image, server, version);
+
+        // Assert
+        Assert.IsEmpty(featuresResult);
+    }
 
     [Test]
     public void VerifyDockerRunningAsync_IsRunning_NoException()

--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -229,14 +229,14 @@ public class DockerServiceTests
           Name = "actions/cache",
           Description = "Control usage of actions/cache inside of workflows. Outputs a comment if not enabled.",
           Enabled = false,
-          EnvName = "FEATURE_ACTIONS_CACHE"
+          EnvName = "FEATURE_ACTIONS_CACHE",
         },
         new Feature
         {
           Name = "composite-actions",
           Description = "Minimizes resulting workflow complexity through the use of composite actions. See https://docs.github.com/en/actions/creating-actions/creating-a-composite-action for more information.",
           Enabled = true,
-          EnvName = "FEATURE_COMPOSITE_ACTIONS"
+          EnvName = "FEATURE_COMPOSITE_ACTIONS",
         }
       };
         var featuresJSON = JsonSerializer.Serialize(features);
@@ -259,7 +259,6 @@ public class DockerServiceTests
         // Assert
         Assert.AreEqual(featuresJSON, featuresResultJSON);
     }
-    // }
 
     [Test]
     public async Task GetFeaturesAsync_BadJSONReturnsEmptyList()

--- a/src/ActionsImporter/App.cs
+++ b/src/ActionsImporter/App.cs
@@ -102,7 +102,8 @@ public class App
     public async Task<int> ConfigureAsync()
     {
         var currentVariables = await _configurationService.ReadCurrentVariablesAsync().ConfigureAwait(false);
-        var newVariables = _configurationService.GetUserInput();
+        var availableFeatures = await _dockerService.GetFeaturesAsync(ActionsImporterImage, ActionsImporterContainerRegistry, ImageTag).ConfigureAwait(false);
+        var newVariables = _configurationService.GetUserInput(availableFeatures);
         var mergedVariables = _configurationService.MergeVariables(currentVariables, newVariables);
         await _configurationService.WriteVariablesAsync(mergedVariables);
 

--- a/src/ActionsImporter/App.cs
+++ b/src/ActionsImporter/App.cs
@@ -115,7 +115,7 @@ public class App
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.Message);
+                await Console.Error.WriteLineAsync(e.Message);
                 return 1;
             }
         }
@@ -127,7 +127,7 @@ public class App
         var mergedVariables = _configurationService.MergeVariables(currentVariables, newVariables);
         await _configurationService.WriteVariablesAsync(mergedVariables);
 
-        Console.WriteLine("Environment variables successfully updated.");
+        await Console.Out.WriteLineAsync("Environment variables successfully updated.");
         return 0;
     }
 }

--- a/src/ActionsImporter/Commands/Configure.cs
+++ b/src/ActionsImporter/Commands/Configure.cs
@@ -1,12 +1,23 @@
 ﻿using System.CommandLine;
-using System.CommandLine.NamingConventionBinder;
+using ActionsImporter.Handlers;
 
 namespace ActionsImporter.Commands;
 
 public class Configure : BaseCommand
 {
+    private readonly string[] _args;
     protected override string Name => "configure";
     protected override string Description => "Start an interactive prompt to configure credentials used to authenticate with your CI server(s).";
+
+    public static readonly Option<bool> OptionalFeaturesOption = new(new[] { "--optional-features" })
+    {
+        Description = "Configure features to customize your usage of GitHub Actions Importer"
+    };
+
+    public Configure(string[] args)
+    {
+        _args = args;
+    }
 
     protected override Command GenerateCommand(App app)
     {
@@ -14,7 +25,8 @@ public class Configure : BaseCommand
 
         var command = base.GenerateCommand(app);
 
-        command.Handler = CommandHandler.Create(app.ConfigureAsync);
+        command.AddGlobalOption(OptionalFeaturesOption);
+        command.SetHandler(new ConfigureHandler(app).Run(_args));
 
         return command;
     }

--- a/src/ActionsImporter/Commands/Configure.cs
+++ b/src/ActionsImporter/Commands/Configure.cs
@@ -9,9 +9,9 @@ public class Configure : BaseCommand
     protected override string Name => "configure";
     protected override string Description => "Start an interactive prompt to configure credentials used to authenticate with your CI server(s).";
 
-    public static readonly Option<bool> OptionalFeaturesOption = new(new[] { "--optional-features" })
+    public static readonly Option<bool> OptionalFeaturesOption = new(new[] { "--features" })
     {
-        Description = "Configure features to customize your usage of GitHub Actions Importer"
+        Description = "Configure the feature flags for GitHub Actions Importer."
     };
 
     public Configure(string[] args)

--- a/src/ActionsImporter/Commands/ListFeatures.cs
+++ b/src/ActionsImporter/Commands/ListFeatures.cs
@@ -12,5 +12,7 @@ public class ListFeatures : ContainerCommand
     protected override string Name => "list-features";
     protected override string Description => "List the available feature flags for GitHub Actions Importer.";
 
-    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>();
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        new Option<bool>(new[] { "--json", "-j" }, "Output the list of features in JSON format.")
+    );
 }

--- a/src/ActionsImporter/Handlers/ConfigureHandler.cs
+++ b/src/ActionsImporter/Handlers/ConfigureHandler.cs
@@ -1,0 +1,13 @@
+﻿namespace ActionsImporter.Handlers;
+
+public class ConfigureHandler
+{
+    private readonly App _app;
+
+    public ConfigureHandler(App app)
+    {
+        _app = app;
+    }
+
+    public Func<Task<int>> Run(string[] args) => () => _app.ConfigureAsync(args);
+}

--- a/src/ActionsImporter/Interfaces/IConfigurationService.cs
+++ b/src/ActionsImporter/Interfaces/IConfigurationService.cs
@@ -6,7 +6,8 @@ namespace ActionsImporter.Interfaces;
 public interface IConfigurationService
 {
     Task<ImmutableDictionary<string, string>> ReadCurrentVariablesAsync(string filePath = ".env.local");
-    ImmutableDictionary<string, string> GetUserInput(List<Feature> features);
+    ImmutableDictionary<string, string> GetFeaturesInput(List<Feature> features);
+    ImmutableDictionary<string, string> GetUserInput();
     Task WriteVariablesAsync(ImmutableDictionary<string, string> variables, string filePath = ".env.local");
 
     ImmutableDictionary<string, string> MergeVariables(ImmutableDictionary<string, string> currentVariables, ImmutableDictionary<string, string> newVariables)

--- a/src/ActionsImporter/Interfaces/IConfigurationService.cs
+++ b/src/ActionsImporter/Interfaces/IConfigurationService.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Immutable;
+using ActionsImporter.Models;
 
 namespace ActionsImporter.Interfaces;
 
 public interface IConfigurationService
 {
     Task<ImmutableDictionary<string, string>> ReadCurrentVariablesAsync(string filePath = ".env.local");
-    ImmutableDictionary<string, string> GetUserInput();
+    ImmutableDictionary<string, string> GetUserInput(List<Feature> features);
     Task WriteVariablesAsync(ImmutableDictionary<string, string> variables, string filePath = ".env.local");
 
     ImmutableDictionary<string, string> MergeVariables(ImmutableDictionary<string, string> currentVariables, ImmutableDictionary<string, string> newVariables)

--- a/src/ActionsImporter/Interfaces/IDockerService.cs
+++ b/src/ActionsImporter/Interfaces/IDockerService.cs
@@ -1,10 +1,14 @@
-﻿namespace ActionsImporter.Interfaces;
+﻿using ActionsImporter.Models;
+
+namespace ActionsImporter.Interfaces;
 
 public interface IDockerService
 {
     Task UpdateImageAsync(string image, string server, string version);
 
     Task ExecuteCommandAsync(string image, string server, string version, params string[] arguments);
+
+    Task<List<Feature>> GetFeaturesAsync(string image, string server, string version);
 
     Task VerifyDockerRunningAsync();
 

--- a/src/ActionsImporter/Models/Feature.cs
+++ b/src/ActionsImporter/Models/Feature.cs
@@ -7,8 +7,8 @@ public class Feature
     public string Name { get; set; } = string.Empty;
 
     public string Description { get; set; } = string.Empty;
-    [JsonPropertyName("env_name")]
 
+    [JsonPropertyName("env_name")]
     public string EnvName { get; set; } = string.Empty;
 
     public bool Enabled { get; set; }

--- a/src/ActionsImporter/Models/Feature.cs
+++ b/src/ActionsImporter/Models/Feature.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ActionsImporter.Models;
+
+public class Feature
+{
+    public string Name { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+    [JsonPropertyName("env_name")]
+
+    public string EnvName { get; set; } = string.Empty;
+
+    public bool Enabled { get; set; }
+
+    public string EnabledMessage() => Enabled ? "enabled" : "disabled";
+}

--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -24,7 +24,7 @@ var command = new RootCommand(welcomeMessage)
 {
     new Update().Command(app),
     new Version().Command(app),
-    new Configure().Command(app),
+    new Configure(args).Command(app),
     new Audit(args).Command(app),
     new Forecast(args).Command(app),
     new DryRun(args).Command(app),

--- a/src/ActionsImporter/Services/ConfigurationService.cs
+++ b/src/ActionsImporter/Services/ConfigurationService.cs
@@ -30,10 +30,8 @@ public class ConfigurationService : IConfigurationService
 
     public ImmutableDictionary<string, string> GetFeaturesInput(List<Feature> features)
     {
-        if (features == null || features.Count < 1)
-        {
-            throw new Exception("No features were found. Please make sure you have the latest version of GitHub Actions Importer.");
-        }
+        ArgumentNullException.ThrowIfNull(features);
+        if (!features.Any()) throw new ArgumentException(message: "No features were found. Please make sure you have the latest version of GitHub Actions Importer.");
 
         var input = ImmutableDictionary.CreateBuilder<string, string>();
         var featureIndices = Prompt.MultiSelect("Which features would you like to configure?", Enumerable.Range(0, features.Count).ToArray(), textSelector: i => features[i].Name);
@@ -45,7 +43,7 @@ public class ConfigurationService : IConfigurationService
 
             if (choice != feature.Enabled)
             {
-                input[feature.EnvName] = choice ? "true" : "false";
+                input[feature.EnvName] = choice.ToString().ToUpperInvariant();
             }
         }
 
@@ -87,7 +85,6 @@ public class ConfigurationService : IConfigurationService
                 input[variable.Key] = variableValue;
             }
         }
-
 
         return input.ToImmutable();
     }

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using ActionsImporter.Interfaces;
 using ActionsImporter.Models.Docker;
+using ActionsImporter.Models;
 
 namespace ActionsImporter.Services;
 
@@ -53,6 +54,28 @@ public class DockerService : IDockerService
             Directory.GetCurrentDirectory(),
             new[] { ("MSYS_NO_PATHCONV", "1") }
         );
+    }
+
+    public async Task<List<Feature>> GetFeaturesAsync(string image, string server, string version)
+    {
+        var actionsImporterArguments = new List<string> { "run --rm -t" };
+        actionsImporterArguments.AddRange(GetEnvironmentVariableArguments());
+        actionsImporterArguments.Add($"{server}/{image}:{version}");
+        actionsImporterArguments.AddRange(new[] { "list-features", "--json" });
+
+        var (standardOutput, _, _) = await _processService.RunAndCaptureAsync("docker", string.Join(' ', actionsImporterArguments), throwOnError: false);
+
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        try
+        {
+            return JsonSerializer.Deserialize<List<Feature>>(standardOutput, options) ?? new();
+        }
+        catch (Exception)
+        {
+            // If unable to get the features from the container, return an empty list
+            // This will allow the customer to continue without configuring any features
+            return new();
+        }
     }
 
     public async Task VerifyDockerRunningAsync()

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -73,7 +73,7 @@ public class DockerService : IDockerService
         catch (Exception)
         {
             // If unable to get the features from the container, return an empty list
-            // This will allow the customer to continue without configuring any features
+            // An empty list will result in a message being displayed to the user
             return new();
         }
     }

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -65,7 +65,7 @@ public class DockerService : IDockerService
 
         var (standardOutput, _, _) = await _processService.RunAndCaptureAsync("docker", string.Join(' ', actionsImporterArguments), throwOnError: false);
 
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, };
         try
         {
             return JsonSerializer.Deserialize<List<Feature>>(standardOutput, options) ?? new();


### PR DESCRIPTION
## What's changing?
This uses the changes from github/valet#5879 to fetch available flags
via the list-features --json flag. It parses out the possible env vars
and walks the customer through setting any feature flags they desire.

This is done by adding a new configure flag: `gh actions-importer configure --optional-features` which walks the user through enabling or disabling available feature flags.

If there are any issues getting the available feature flags JSON, we initialize an empty list of flags and make sure the customer is up to date.


https://user-images.githubusercontent.com/13201458/229934268-87102184-b16b-4482-b8aa-bb277150f840.mov



## How's this tested?
* Specs
* A few commands:
    * If you run configure _before_ using the new docker container introduced in github/valet#5879 (`dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- configure --optional-features`), it shouldn't ask you to configure flags and shouldn't error
      * Pull an older docker image from before the above PR: `docker pull ghcr.io/actions-importer/cli:1.2.17722`
      * Run `docker image tag ghcr.io/actions-importer/cli:1.2.17722 ghcr.io/actions-importer/cli:latest`
    * Using the new env toggles:
      * Pull the latest docker image `docker pull ghcr.io/actions-importer/cli:latest`
      * Then run `dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- configure --optional-features`
      * This adds a new menu that lets you optionally set feature flags. Try enabling/disabling some flags and see that your .env.local file gets updated correctly
    * The `configure` command without any additional option(s) should function as it previously did. 

Closes github/valet#5760
