### PR TITLE
Add Bamboo support to configure command

### DIFF
--- a/src/ActionsImporter.UnitTests/Models/VariableTests.cs
+++ b/src/ActionsImporter.UnitTests/Models/VariableTests.cs
@@ -12,6 +12,7 @@ public class VariableTests
     [TestCase(Provider.GitLabCI, "GitLab CI")]
     [TestCase(Provider.Jenkins, "Jenkins")]
     [TestCase(Provider.TravisCI, "Travis CI")]
+    [TestCase(Provider.Bamboo, "Bamboo")]
     public void ProviderName_ValidName_ReturnsExpected(Provider provider, string providerName)
     {
         // Arrange

--- a/src/ActionsImporter/Constants.cs
+++ b/src/ActionsImporter/Constants.cs
@@ -12,6 +12,8 @@ public static class Constants
         new Variable("AZURE_DEVOPS_INSTANCE_URL", Provider.AzureDevOps, "Base url of the Azure DevOps instance", "https://dev.azure.com"),
         new Variable("AZURE_DEVOPS_ORGANIZATION", Provider.AzureDevOps, "Azure DevOps organization name"),
         new Variable("AZURE_DEVOPS_PROJECT", Provider.AzureDevOps, "Azure DevOps project name"),
+        new Variable("BAMBOO_ACCESS_TOKEN", Provider.Bamboo, "Personal access token for Bamboo"),
+        new Variable("BAMBOO_INSTANCE_URL", Provider.Bamboo, "Base url of the Bamboo instance"),
         new Variable("CIRCLE_CI_ACCESS_TOKEN", Provider.CircleCI, "Personal access token for CircleCI"),
         new Variable("CIRCLE_CI_INSTANCE_URL", Provider.CircleCI, "Base url of the CircleCI instance", "https://circleci.com"),
         new Variable("CIRCLE_CI_ORGANIZATION", Provider.CircleCI, "CircleCI organization name"),
@@ -24,6 +26,8 @@ public static class Constants
         new Variable("TRAVIS_CI_INSTANCE_URL", Provider.TravisCI, "Base url of the Travis CI instance", "https://travis-ci.com"),
         new Variable("TRAVIS_CI_ORGANIZATION", Provider.TravisCI, "Travis CI organization name")
     };
+
+    public static List<string> ProviderNames => UserInputVariables.Where(v => v.Provider != Provider.GitHub).Select(v => v.ProviderName).Distinct().ToList();
 
     public static List<string> EnvironmentVariables
     {

--- a/src/ActionsImporter/Models/Provider.cs
+++ b/src/ActionsImporter/Models/Provider.cs
@@ -7,5 +7,6 @@ public enum Provider
     CircleCI,
     GitLabCI,
     Jenkins,
-    TravisCI
+    TravisCI,
+    Bamboo
 }

--- a/src/ActionsImporter/Models/Variable.cs
+++ b/src/ActionsImporter/Models/Variable.cs
@@ -19,6 +19,7 @@ public readonly struct Variable
         Provider.GitLabCI => "GitLab CI",
         Provider.Jenkins => "Jenkins",
         Provider.TravisCI => "Travis CI",
+        Provider.Bamboo => "Bamboo",
         _ => throw new ArgumentOutOfRangeException()
     };
 
@@ -28,5 +29,5 @@ public readonly struct Variable
 
     public string? Placeholder => DefaultValue is not null && IsPassword ? $"({DefaultValue})" : null;
 
-    private Provider Provider { get; }
+    public Provider Provider { get; }
 }

--- a/src/ActionsImporter/Services/ConfigurationService.cs
+++ b/src/ActionsImporter/Services/ConfigurationService.cs
@@ -53,8 +53,7 @@ public class ConfigurationService : IConfigurationService
     {
         var providers = Prompt.MultiSelect(
             "Which CI providers are you configuring?",
-            new[] { "Azure DevOps", "CircleCI", "GitLab CI", "Jenkins", "Travis CI" },
-            pageSize: 5
+            Constants.ProviderNames
         );
 
         var input = ImmutableDictionary.CreateBuilder<string, string>();


### PR DESCRIPTION
🚧 DO NOT MERGE UNTIL BAMBOO BETA RELEASE 🚧 
----
## What's changing?
* Adds Bamboo support to the `configure` command.
* I also updated the configure list of providers to use the Enum so that it's dynamic

## How's this tested?
* Specs
* Run `dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- configure` and run through the Bamboo option

Closes github/valet#5755
