### PR TITLE
Build Apple arm64 binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,14 @@ jobs:
         run: |
           dotnet publish src/ActionsImporter/ActionsImporter.csproj -c Release -r win10-x64 --self-contained -o dist/win-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
           dotnet publish src/ActionsImporter/ActionsImporter.csproj -c Release -r osx-x64 --self-contained -o dist/osx-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+          dotnet publish src/ActionsImporter/ActionsImporter.csproj -c Release -r osx-arm64 --self-contained -o dist/osx-arm64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
           dotnet publish src/ActionsImporter/ActionsImporter.csproj -c Release -r linux-x64 --self-contained -o dist/linux-x64 --no-restore -p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
       - name: prepare staging
         run: |
           mkdir -p ${{ runner.temp }}/staging
           cp dist/win-x64/gh-actions-importer.exe ${{ runner.temp }}/staging/actions-importer-windows-amd64.exe
           cp dist/osx-x64/gh-actions-importer ${{ runner.temp }}/staging/actions-importer-darwin-amd64
+          cp dist/osx-arm64/gh-actions-importer ${{ runner.temp }}/staging/actions-importer-darwin-arm64
           cp dist/linux-x64/gh-actions-importer ${{ runner.temp }}/staging/actions-importer-linux-amd64
 
       - name: publish artifacts
@@ -112,4 +114,5 @@ jobs:
           files: |
             ${{ runner.temp }}/dist/actions-importer-windows-amd64.exe
             ${{ runner.temp }}/dist/actions-importer-linux-amd64
+            ${{ runner.temp }}/dist/actions-importer-darwin-arm64
             ${{ runner.temp }}/dist/actions-importer-darwin-amd64

--- a/src/ActionsImporter/ActionsImporter.csproj
+++ b/src/ActionsImporter/ActionsImporter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <RuntimeIdentifiers>win10-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x64;osx-x64;osx-arm64;linux-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>gh-actions-importer</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
## What's changing?

This builds a native darwin-arm64 binary so that Rosetta is not needed to be installed on an Apple silicon machine to run the CLI extension.

## How's this tested?

We'll publish an ad-hoc release and verify it functions on both Apple and Intel chip machines

Related to #104 
