### PR TITLE
Fix: command option types

### DIFF
--- a/src/ActionsImporter/Commands/Bamboo/Audit.cs
+++ b/src/ActionsImporter/Commands/Bamboo/Audit.cs
@@ -16,7 +16,6 @@ public class Audit : ContainerCommand
         Common.AccessToken,
         Common.InstanceUrl,
         Common.Project,
-        Common.ConfigFilePath,
-        Common.IncludeFrom
+        Common.ConfigFilePath
     );
 }

--- a/src/ActionsImporter/Commands/Bamboo/Common.cs
+++ b/src/ActionsImporter/Commands/Bamboo/Common.cs
@@ -40,13 +40,13 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<int> PlanSlug = new(new[] { "-p", "--plan-slug" })
+    public static readonly Option<string> PlanSlug = new(new[] { "-p", "--plan-slug" })
     {
         Description = "The project and plan key in the format 'ProjectKey-PlanKey'.",
         IsRequired = true,
     };
 
-    public static readonly Option<FileInfo> DeploymentProjectId = new("--deployment-project-id")
+    public static readonly Option<int> DeploymentProjectId = new("--deployment-project-id")
     {
         Description = "The Bamboo deployment project id.",
         IsRequired = true,

--- a/src/ActionsImporter/Commands/Bamboo/Common.cs
+++ b/src/ActionsImporter/Commands/Bamboo/Common.cs
@@ -34,12 +34,6 @@ public static class Common
         IsRequired = false,
     };
 
-    public static readonly Option<FileInfo> IncludeFrom = new("--include-from")
-    {
-        Description = "The file path containing a list of line-delimited repositories to include in the audit.",
-        IsRequired = false,
-    };
-
     public static readonly Option<string> PlanSlug = new(new[] { "-p", "--plan-slug" })
     {
         Description = "The project and plan key in the format 'ProjectKey-PlanKey'.",


### PR DESCRIPTION
## What's changing?

Fixes that came out of manual testing by the team. 

To be merged after https://github.com/github/valet/pull/6208. Those changes fix a bug we found when running
```
audit bamboo -o tmp/ --confi-file-path some.yml
```

## How's this tested?

Manually

For the commands that take in `--source-file-path` I took a copy of the YAML of the `IN-COM` build and saved it locally. For the `migrate` commands I created a private repo and tested against that. 

The following commands have all succeeded. I'll update this block as a I go.

```sh
# for convenience
export PROJ=src/ActionsImporter/ActionsImporter.csproj


# Audit

dotnet run --project $PROJ -- audit bamboo -o tmp/

dotnet run --project $PROJ -- audit bamboo -o tmp/ --project IN

dotnet run --project $PROJ -- audit bamboo -o tmp/ -p IN


# Dry Run

dotnet run --project $PROJ -- dry-run bamboo deployment -o tmp/ --deployment-project-id 6553605

dotnet run --project $PROJ -- dry-run bamboo build -o tmp/ --plan-slug IN-COM

dotnet run --project $PROJ -- dry-run bamboo build -o tmp/ -p IN-COM

dotnet run --project $PROJ -- dry-run bamboo build -o tmp/ --plan-slug foo --source-file-path sample.yml

dotnet run --project $PROJ -- dry-run bamboo build -o tmp/ -p foo --source-file-path sample.yml

dotnet run --project $PROJ -- dry-run bamboo build -o tmp/ -p IN-COM --config-file-path config.yml

dotnet run --project $PROJ -- dry-run bamboo build -o tmp/ --plan-slug IN-COM --config-file-path config.yml


# Migrate

dotnet run --project $PROJ -- migrate bamboo deployment -o tmp/ --deployment-project-id 6553605 --target-url https://github.com/simonsanchez/valet-testing-integration

dotnet run --project $PROJ -- migrate bamboo build -o tmp/ --plan-slug IN-COM --target-url https://github.com/simonsanchez/valet-testing-integration

dotnet run --project $PROJ -- migrate bamboo build -o tmp/ -p IN-COM --target-url https://github.com/simonsanchez/valet-testing-integration

dotnet run --project $PROJ -- migrate bamboo build -o tmp/ --plan-slug foo --source-file-path sample.yml --target-url https://github.com/simonsanchez/valet-testing-integration

dotnet run --project $PROJ -- migrate bamboo build -o tmp/ -p foo --source-file-path sample.yml --target-url https://github.com/simonsanchez/valet-testing-integration

dotnet run --project $PROJ -- migrate bamboo build -o tmp/ --plan-slug IN-COM --config-file-path config.yml --target-url https://github.com/simonsanchez/valet-testing-integration

dotnet run --project $PROJ -- migrate bamboo build -o tmp/ -p IN-COM --config-file-path config.yml --target-url https://github.com/simonsanchez/valet-testing-integration
```

Closes: https://github.com/github/valet/issues/6210
