### PR TITLE
Expose `forecast` command for Bamboo

### DIFF
--- a/src/ActionsImporter/Commands/Bamboo/Forecast.cs
+++ b/src/ActionsImporter/Commands/Bamboo/Forecast.cs
@@ -1,0 +1,28 @@
+using System.Collections.Immutable;
+using System.CommandLine;
+
+namespace ActionsImporter.Commands.Bamboo;
+
+public class Forecast : ContainerCommand
+{
+    public Forecast(string[] args) : base(args)
+    {
+    }
+
+    protected override string Name => "bamboo";
+    protected override string Description => "Forecasts GitHub Actions usage from historical Bamboo pipeline utilization.";
+
+    private static readonly Option<FileInfo[]> SourceFilePath = new("--source-file-path")
+    {
+        Description = "The file path(s) to existing jobs data.",
+        IsRequired = false,
+        AllowMultipleArgumentsPerToken = true,
+    };
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.Project,
+        Common.InstanceUrl,
+        Common.AccessToken,
+        SourceFilePath
+    );
+}

--- a/src/ActionsImporter/Commands/Bamboo/Forecast.cs
+++ b/src/ActionsImporter/Commands/Bamboo/Forecast.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.CommandLine;
 
 namespace ActionsImporter.Commands.Bamboo;

--- a/src/ActionsImporter/Commands/Forecast.cs
+++ b/src/ActionsImporter/Commands/Forecast.cs
@@ -54,6 +54,7 @@ public class Forecast : ContainerCommand
         command.AddCommand(new Circle.Forecast(_args).Command(app));
         command.AddCommand(new Travis.Forecast(_args).Command(app));
         command.AddCommand(new GitHub.Forecast(_args).Command(app));
+        command.AddCommand(new Bamboo.Forecast(_args).Command(app));
 
         return command;
     }


### PR DESCRIPTION
## What's changing?
Exposes the `forecast` command for Bamboo

Try it out!
```
dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- forecast bamboo -o output/audit

dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- forecast bamboo -o output/audit --start-date 01/01/2023
```
> Note make sure to pull the latest container to ensure you have forecast support with `gh actions-importer update`

## How's this tested?
👀 

Closes github/valet/issues/6233
