### PR TITLE
Add a mode that validates CLI commands/options only

### DIFF
--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -52,6 +52,22 @@ var parser = new CommandLineBuilder(command)
 var parsedArguments = parser.Parse(args);
 app.IsPrerelease = parsedArguments.HasOption(Common.Prerelease);
 
+var testCommandOnly = Environment.GetEnvironmentVariable("TEST_COMMAND_ONLY");
+if (testCommandOnly != null && testCommandOnly.ToUpperInvariant() == "TRUE")
+{
+    if (parsedArguments.Errors.Count > 0)
+    {
+        foreach (var error in parsedArguments.Errors)
+        {
+            Console.WriteLine(error.Message);
+        }
+        return 1;
+    }
+
+    Console.WriteLine("Valid command!");
+    return 0;
+}
+
 try
 {
     if (!Array.Exists(args, x => x == "update"))


### PR DESCRIPTION
## What's changing?
* Add an env var `TEST_COMMAND_ONLY`, which only runs the CLI parser
    * Exits 1 or 0 depending on parser result
    * Prints errors to console
    * For use by https://github.com/github/valet/pull/6289 
        * This allows us to run commands _only_ to see if the two CLIs are "in sync" and help us find which options from the Ruby side aren't supported here

Open to better ENV var name suggestions! Also if there's somewhere else I can put this other than `Program.cs` I'd love to know, as that file is getting somewhat long and complex.

## How's this tested?
```shell
# Exit 0 w/ success message
TEST_COMMAND_ONLY=true dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- dry-run bamboo build -o tmp -p proj
# Exit 1 & output error message(s)
TEST_COMMAND_ONLY=true dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- dry-run bamboo build
# Run the command as normal
dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- dry-run bamboo build
```


Related github/valet#6371
