### PR TITLE
Add option to disable the use of host network

### DIFF
--- a/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
+++ b/src/ActionsImporter.UnitTests/Services/DockerServiceTests.cs
@@ -103,6 +103,8 @@ public class DockerServiceTests
         var server = "ghcr.io";
         var version = "latest";
         var arguments = new[] { "run", "this", "command" };
+        var noHostNetwork = false;
+
         _processService.Setup(handler =>
             handler.RunAsync(
                 "docker",
@@ -114,7 +116,7 @@ public class DockerServiceTests
         ).Returns(Task.CompletedTask);
 
         // Act
-        await _dockerService.ExecuteCommandAsync(image, server, version, arguments);
+        await _dockerService.ExecuteCommandAsync(image, server, version, noHostNetwork, arguments);
 
         // Assert
         _processService.VerifyAll();
@@ -127,6 +129,7 @@ public class DockerServiceTests
         var image = "actions-importer/cli";
         var server = "ghcr.io";
         var version = "latest";
+        var noHostNetwork = false;
         var arguments = new[] { "run", "this", "command" };
 
         Environment.SetEnvironmentVariable("GH_ACCESS_TOKEN", "foo");
@@ -144,7 +147,7 @@ public class DockerServiceTests
         ).Returns(Task.CompletedTask);
 
         // Act
-        await _dockerService.ExecuteCommandAsync(image, server, version, arguments);
+        await _dockerService.ExecuteCommandAsync(image, server, version, noHostNetwork, arguments);
 
         // Assert
         _processService.VerifyAll();
@@ -157,6 +160,7 @@ public class DockerServiceTests
         var image = "actions-importer/cli";
         var server = "ghcr.io";
         var version = "latest";
+        var noHostNetwork = false;
         var arguments = new[] { "run", "this", "command" };
 
         Environment.SetEnvironmentVariable("DOCKER_ARGS", "--network=host");
@@ -172,7 +176,7 @@ public class DockerServiceTests
         ).Returns(Task.CompletedTask);
 
         // Act
-        await _dockerService.ExecuteCommandAsync(image, server, version, arguments);
+        await _dockerService.ExecuteCommandAsync(image, server, version, noHostNetwork, arguments);
 
         // Assert
         _processService.VerifyAll();
@@ -185,6 +189,7 @@ public class DockerServiceTests
         var image = "actions-importer/cli";
         var server = "ghcr.io";
         var version = "latest";
+        var noHostNetwork = true;
         var arguments = new[] { "run", "this", "command" };
 
         _runtimeService.Setup(handler => handler.IsLinux).Returns(true);
@@ -200,7 +205,7 @@ public class DockerServiceTests
         _processService.Setup(handler =>
             handler.RunAsync(
                 "docker",
-                $"run --rm -t --network=host -e USER_ID=50 -e GROUP_ID=100 -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
+                $"run --rm -t -e USER_ID=50 -e GROUP_ID=100 -v \"{Directory.GetCurrentDirectory()}\":/data {server}/{image}:{version} {string.Join(' ', arguments)}",
                 Directory.GetCurrentDirectory(),
                 new[] { new ValueTuple<string, string>("MSYS_NO_PATHCONV", "1") },
                 true
@@ -208,7 +213,7 @@ public class DockerServiceTests
         ).Returns(Task.CompletedTask);
 
         // Act
-        await _dockerService.ExecuteCommandAsync(image, server, version, arguments);
+        await _dockerService.ExecuteCommandAsync(image, server, version, noHostNetwork, arguments);
 
         // Assert
         _processService.VerifyAll();

--- a/src/ActionsImporter/App.cs
+++ b/src/ActionsImporter/App.cs
@@ -14,6 +14,7 @@ public class App
     private readonly IConfigurationService _configurationService;
 
     public bool IsPrerelease { get; set; }
+    public bool NoHostNetwork { get; set; }
 
     private string ImageTag => IsPrerelease ? "pre" : "latest";
 
@@ -53,6 +54,7 @@ public class App
             ActionsImporterImage,
             ActionsImporterContainerRegistry,
             ImageTag,
+            NoHostNetwork,
             args.Select(x => x.EscapeIfNeeded()).ToArray()
         );
         return 0;

--- a/src/ActionsImporter/Commands/Common.cs
+++ b/src/ActionsImporter/Commands/Common.cs
@@ -21,7 +21,7 @@ public static class Common
 
     public static readonly Option<bool> NoHostNetwork = new("--no-host-network")
     {
-        Description = "Disable using host network.",
+        Description = "Use docker's default bridge network instead of the host machine's network.",
         IsRequired = false,
     };
 

--- a/src/ActionsImporter/Commands/Common.cs
+++ b/src/ActionsImporter/Commands/Common.cs
@@ -19,6 +19,12 @@ public static class Common
         IsHidden = true
     };
 
+    public static readonly Option<bool> NoHostNetwork = new("--no-host-network")
+    {
+        Description = "Disable using host network.",
+        IsRequired = false,
+    };
+
     public static Command AppendTransformerOptions(this Command command)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -148,6 +154,8 @@ public static class Common
         command.AddGlobalOption(Experimental);
 
         command.AddGlobalOption(Prerelease);
+
+        command.AddGlobalOption(NoHostNetwork);
 
         return command;
     }

--- a/src/ActionsImporter/Commands/ContainerCommand.cs
+++ b/src/ActionsImporter/Commands/ContainerCommand.cs
@@ -10,8 +10,8 @@ public abstract class ContainerCommand : BaseCommand
 
     protected ContainerCommand(string[] args)
     {
-        // Don't forward the --prerelease flag to GitHub Actions Importer image
-        _args = args.Where(arg => !arg.Contains(Common.Prerelease.Name, StringComparison.Ordinal)).ToArray();
+        // Don't forward the --prerelease or --no-host-network flag to GitHub Actions Importer image
+        _args = args.Where(arg => !arg.Contains(Common.Prerelease.Name, StringComparison.Ordinal) && !arg.Contains(Common.NoHostNetwork.Name, StringComparison.Ordinal)).ToArray();
     }
 
     protected abstract ImmutableArray<Option> Options { get; }

--- a/src/ActionsImporter/Interfaces/IDockerService.cs
+++ b/src/ActionsImporter/Interfaces/IDockerService.cs
@@ -6,7 +6,7 @@ public interface IDockerService
 {
     Task UpdateImageAsync(string image, string server, string version);
 
-    Task ExecuteCommandAsync(string image, string server, string version, params string[] arguments);
+    Task ExecuteCommandAsync(string image, string server, string version, bool noHostNetwork, params string[] arguments);
 
     Task<List<Feature>> GetFeaturesAsync(string image, string server, string version);
 

--- a/src/ActionsImporter/Program.cs
+++ b/src/ActionsImporter/Program.cs
@@ -51,6 +51,7 @@ var parser = new CommandLineBuilder(command)
 
 var parsedArguments = parser.Parse(args);
 app.IsPrerelease = parsedArguments.HasOption(Common.Prerelease);
+app.NoHostNetwork = parsedArguments.HasOption(Common.NoHostNetwork);
 
 var testCommandOnly = Environment.GetEnvironmentVariable("TEST_COMMAND_ONLY");
 if (testCommandOnly != null && testCommandOnly.ToUpperInvariant() == "TRUE")

--- a/src/ActionsImporter/Services/DockerService.cs
+++ b/src/ActionsImporter/Services/DockerService.cs
@@ -21,12 +21,18 @@ public class DockerService : IDockerService
         return DockerPullAsync(image, server, version);
     }
 
-    public async Task ExecuteCommandAsync(string image, string server, string version, params string[] arguments)
+    public async Task ExecuteCommandAsync(string image, string server, string version, bool noHostNetwork, params string[] arguments)
     {
         var actionsImporterArguments = new List<string>
         {
-            "run --rm -t --network=host"
+            "run --rm -t"
         };
+
+        if (!noHostNetwork)
+        {
+            actionsImporterArguments.Add("--network=host");
+        }
+
         actionsImporterArguments.AddRange(GetEnvironmentVariableArguments());
 
         var dockerArgs = Environment.GetEnvironmentVariable("DOCKER_ARGS");


### PR DESCRIPTION
## What's changing?
Adds a new CLI flag `--no-host-network` to prevent the use of the host network while running the docker commands.  If the flag is not present then the docker run command is generate as it was before with the `--network=host`.  When the new flag is present the `--network=host` will not be added.  

Relates to #172 

## How's this tested?
specs and 👀 

Closes github/valet/issues/6619
