### PR TITLE
Add --include-from option to GitHub forecast

### DIFF
--- a/src/ActionsImporter/Commands/GitHub/Forecast.cs
+++ b/src/ActionsImporter/Commands/GitHub/Forecast.cs
@@ -36,6 +36,12 @@ public class Forecast : ContainerCommand
         IsRequired = false,
     };
 
+    private static readonly Option<FileInfo> IncludeFrom = new("--include-from")
+    {
+        Description = "The file path containing a list of line-delimited repository names to include in the forecast.",
+        IsRequired = false,
+    };
+
     private static readonly Option<FileInfo[]> SourceFilePath = new("--source-file-path")
     {
         Description = "The file path(s) to existing jobs data.",
@@ -48,6 +54,7 @@ public class Forecast : ContainerCommand
         AccessToken,
         Organization,
         Repository,
+        IncludeFrom,
         SourceFilePath
     );
 }


### PR DESCRIPTION
## What's changing?
* Add the `--include-from` option to support splitting GitHub forecasts across multiple machines/CLI invocations.

## How's this tested?
* Run `dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- forecast github --help` and see that the new --include-from option is included and matches the one in github/valet#6672

Closes github/valet#6618
