### PR TITLE
Bitbucket:  Add support for `forecast` command

### DIFF
--- a/src/ActionsImporter/Commands/Bitbucket/Forecast.cs
+++ b/src/ActionsImporter/Commands/Bitbucket/Forecast.cs
@@ -19,10 +19,17 @@ public class Forecast : ContainerCommand
         AllowMultipleArgumentsPerToken = true,
     };
 
+    private static readonly Option<FileInfo> IncludeFrom = new("--include-from")
+    {
+        Description = "The file path containing a list of line-delimited repository names to include in the forecast.",
+        IsRequired = false,
+    };
+
     protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
         Common.Project,
         Common.Workspace,
         Common.AccessToken,
-        SourceFilePath
+        SourceFilePath,
+        IncludeFrom
     );
 }

--- a/src/ActionsImporter/Commands/Bitbucket/Forecast.cs
+++ b/src/ActionsImporter/Commands/Bitbucket/Forecast.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Immutable;
+using System.CommandLine;
+
+namespace ActionsImporter.Commands.Bitbucket;
+
+public class Forecast : ContainerCommand
+{
+    public Forecast(string[] args) : base(args)
+    {
+    }
+
+    protected override string Name => "bitbucket";
+    protected override string Description => "Forecasts GitHub Actions usage from historical Bitbucket pipeline utilization.";
+
+    private static readonly Option<FileInfo[]> SourceFilePath = new("--source-file-path")
+    {
+        Description = "The file path(s) to existing jobs data.",
+        IsRequired = false,
+        AllowMultipleArgumentsPerToken = true,
+    };
+
+    protected override ImmutableArray<Option> Options => ImmutableArray.Create<Option>(
+        Common.Project,
+        Common.Workspace,
+        Common.AccessToken,
+        SourceFilePath
+    );
+}

--- a/src/ActionsImporter/Commands/Forecast.cs
+++ b/src/ActionsImporter/Commands/Forecast.cs
@@ -55,6 +55,7 @@ public class Forecast : ContainerCommand
         command.AddCommand(new Travis.Forecast(_args).Command(app));
         command.AddCommand(new GitHub.Forecast(_args).Command(app));
         command.AddCommand(new Bamboo.Forecast(_args).Command(app));
+        command.AddCommand(new Bitbucket.Forecast(_args).Command(app));
 
         return command;
     }


### PR DESCRIPTION
## What's changing?
Adds `forecast` command to Bitbucket

Try it out 🚗 
```shell
dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- forecast bitbucket --workspace actions-importer -o output/forecast 
```

With `--project-key`
```shell
dotnet run --project src/ActionsImporter/ActionsImporter.csproj -- forecast bitbucket --workspace actions-importer -o output/forecast --project-key SW
```
## How's this tested?
👀 

Closes github/valet#7012
