### PR TITLE
Remove verify-command sample

### DIFF
--- a/docs/circle_ci/Orbs/Cypress/Setup.md
+++ b/docs/circle_ci/Orbs/Cypress/Setup.md
@@ -17,7 +17,6 @@ jobs:
           install-command: yarn --frozen-lockfile --silent
           cache-key: cache-{{ arch }}-{{ .Branch }}-{{ checksum "MY_CUSTOM_CACHE_KEY" }}
           working_directory: my/path
-          verify-command: npx verify-mycommand
           yarn: true
 ```
 
@@ -31,8 +30,6 @@ jobs:
 - run: yarn --frozen-lockfile --silent
   working-directory: my/path     
 - uses: actions/checkout@v2
-- run: npx verify-mycommand
-  working-directory: my/path
 - run: npm run build
   working-directory: my/path
 ```


### PR DESCRIPTION
## What's changing?

Remove `verify-command` example from the `CircleCI` docs.

## How's this tested?

Visual. It's just a docs change.

Closes https://github.com/github/valet/issues/7264
