### PR TITLE
Update code block format for `.env.local` in README.md for highlight parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can find detailed information about using environment variables in the platf
 
 We highly recommend using the [official GitHub Container Registry to pull the GitHub Actions Importer Docker image](https://github.com/actions-importer/preview/pkgs/container/cli/). However, if you need to use a custom Docker registry, you can configure GitHub Actions Importer to use a custom Docker registry by setting the `CONTAINER_REGISTRY` environment variable in your `.env.local` file.
 
-```bash
+```.env
 # .env.local
 CONTAINER_REGISTRY=my-custom-registry.com
 ```


### PR DESCRIPTION
## What's changing?
Update code block format from `bash` to `.env` in README.md for highlight parameter in `.env.local` file.

Correct the code block for `.env.local` that we use `.env` that refer from https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml .

```
Dotenv:
  type: data
  color: "#e5d559"
  extensions:
  - ".env"
  filenames:
  - ".env"
  - ".env.ci"
  - ".env.dev"
  - ".env.development"
  - ".env.development.local"
  - ".env.example"
  - ".env.local"
  - ".env.prod"
  - ".env.production"
  - ".env.sample"
  - ".env.staging"
  - ".env.test"
  - ".env.testing"
  tm_scope: source.dotenv
  ace_mode: text
  language_id: 111148035
```