### PR TITLE
Harden GitHub Actions Workflow Permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -85,6 +88,8 @@ jobs:
           path: ${{ runner.temp }}/staging/*
 
   publish:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,6 +2,8 @@
 
 ## Our Pledge
 
+test
+
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,8 +2,6 @@
 
 ## Our Pledge
 
-test
-
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body


### PR DESCRIPTION
## What's changing?

This PR updates the CI workflow to explicitly define `permissions` in accordance with GitHub security best practices and to resolve the `actions/missing-workflow-permissions` CodeQL alert.

- Added top-level `permissions: contents: read` to enforce least-privilege by default.
- Scoped `contents: write` to the `publish` job only (required for release creation).
- Preserved `checks: write` and `pull-requests: write` permissions for the `unit-test` job to support publishing test results.

## How's this tested?

Closes https://github.com/github/gh-actions-importer/security/code-scanning/3
